### PR TITLE
fix(model): use Qwen3VLForConditionalGeneration

### DIFF
--- a/src/token_map.py
+++ b/src/token_map.py
@@ -14,7 +14,7 @@ from typing import List, Tuple, Optional, Dict, Any
 
 import torch
 from PIL import Image
-from transformers import AutoProcessor, Qwen2_5_VLForConditionalGeneration
+from transformers import AutoProcessor, Qwen3VLForConditionalGeneration
 
 
 # ---------------------------------------------------------------------------
@@ -30,18 +30,17 @@ VISION_END_ID: int = 151653
 # ---------------------------------------------------------------------------
 # Module-level model / processor cache — load once, reuse everywhere
 # ---------------------------------------------------------------------------
-_model: Optional[Qwen2_5_VLForConditionalGeneration] = None
+_model: Optional[Qwen3VLForConditionalGeneration] = None
 _processor: Optional[AutoProcessor] = None
 
 
 def load_qwen3vl(
     model_name: str = "Qwen/Qwen3-VL-2B-Instruct",
     device: str = "cpu",
-) -> Tuple[Qwen2_5_VLForConditionalGeneration, AutoProcessor]:
+) -> Tuple[Qwen3VLForConditionalGeneration, AutoProcessor]:
     """
     Lazily load Qwen3-VL model and processor (cached at module level).
 
-    Qwen3-VL uses the Qwen2_5_VL* classes from transformers.
     Model is loaded in bfloat16 to reduce memory pressure.
 
     Args:
@@ -58,7 +57,7 @@ def load_qwen3vl(
         _processor = AutoProcessor.from_pretrained(model_name)
 
         print(f"[token_map] Loading Qwen3-VL model (bfloat16) on {device}...")
-        _model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
+        _model = Qwen3VLForConditionalGeneration.from_pretrained(
             model_name,
             torch_dtype=torch.bfloat16,
         ).to(device)

--- a/src/train_qwen_cosyn.py
+++ b/src/train_qwen_cosyn.py
@@ -17,7 +17,7 @@ from torch.nn.utils import clip_grad_norm_
 
 from transformers import (
     AutoProcessor,
-    Qwen2_5_VLForConditionalGeneration,
+    Qwen3VLForConditionalGeneration,
     get_cosine_schedule_with_warmup,
 )
 from datasets import load_dataset
@@ -271,7 +271,7 @@ def main(config: Config):
     print(f"[train] Loading processor and model: {config.model_name}")
     processor = AutoProcessor.from_pretrained(config.model_name, trust_remote_code=True)
 
-    model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
+    model = Qwen3VLForConditionalGeneration.from_pretrained(
         config.model_name,
         torch_dtype=torch.bfloat16,
         attn_implementation="flash_attention_2",


### PR DESCRIPTION
## Summary
- Updates `token_map.py` and `train_qwen_cosyn.py` to use `Qwen3VLForConditionalGeneration` instead of `Qwen2_5_VLForConditionalGeneration`
- Qwen3-VL has its own dedicated class in `transformers >= 4.57.0` — we were incorrectly using the Qwen2.5-VL class
- Verified all patch grid constants (PATCH_SIZE=16, MERGE_SIZE=2, vision token IDs) are unchanged between Qwen2.5-VL and Qwen3-VL

Addresses @Patchwork53's comment: "I see a Qwen VL 2.5 import. It probably should be Qwen VL 3"

Closes #2

## Test plan
- [ ] Verify `from transformers import Qwen3VLForConditionalGeneration` resolves (requires transformers >= 4.57.0)
- [ ] Run `ocr_to_tokens.py` end-to-end on a sample table image

🤖 Generated with [Claude Code](https://claude.com/claude-code)