### PR TITLE
feat: Qwen3-VL table-text alignment pipeline + experimental results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ dist/
 build/
 .pytest_cache/
 outputs/
+
+# Precomputed alignment data (1050 .pt files, ~7GB; regenerable via src.preprocess_cosyn)
+data/
 .DS_Store
 *.swp
 *.swo

--- a/README.md
+++ b/README.md
@@ -1,75 +1,113 @@
-# Table-Text Alignment for VLMs
+# Cell-Level Table-Text Alignment for Vision-Language Models
 
-**Cell-level alignment loss that pushes a VLM's visual representations of table regions toward the corresponding OCR text — giving the model semantic anchors for every cell.**
+**Senior Research Project (CS297) — Rushi Patel, University of California, Riverside**
 
-> **Headline result (run4, May 2026):** with the `lm_head_bow` auxiliary loss (frozen-LM-head probe per Sameen's "VLM Needs Words"-inspired proposal) at layer 26 of Qwen3-VL-2B-Instruct, the alignment objective **is learnable** (NLL 10.68 → 6.03, well below the random floor of 11.93) — but downstream **EM on CoSyn-400K table QA does not improve** (0.485 vs 0.495 task-only baseline, within statistical noise at n=200). The auxiliary objective is achievable but appears orthogonal to the downstream task on this dataset/model. See [Step 3](#step-3-qwen3-vl-alignment--implementation--results) for the full table and discussion.
+An auxiliary training objective that pushes a vision-language model's internal visual representations of table cells toward their corresponding OCR text, giving the model explicit semantic anchors for every cell in a table image.
 
----
+## Motivation
 
-## How It Works
+Vision-language models (VLMs) like Qwen3-VL can answer questions about table images, but their internal representations of individual table cells are not explicitly tied to the textual content those cells contain. Recent work on intermediate-layer representations — particularly LatentLens (Krojer et al., 2024) and VLMs Need Words (Shahgir et al., 2025) — suggests that VLM hidden states at mid-to-late transformer layers occupy a shared text-image embedding space that can be probed through the model's own language model head.
 
-```
-Step 1 — OCR: Find every cell in the table image (using EasyOCR)
-┌─────────────────────────────────────────────────┐
-│  Table Image                                    │
-│       │                                         │
-│       ▼                                         │
-│  bb_and_text_from_table_image()                 │
-│       │                                         │
-│       ├──► bounding boxes  (where each cell is) │
-│       └──► OCR text        (what each cell says)│
-└─────────────────────────────────────────────────┘
+This project investigates whether **forcing** that alignment via an auxiliary loss during fine-tuning improves downstream table question-answering performance. The core hypothesis: if the model's visual tokens for a cell region are trained to be linguistically decodable (i.e., the frozen LM head can recover the OCR text from the visual hidden states), the model should better understand table structure and content.
 
-Step 2 — Embed: Convert each cell into a vector the model understands
-┌─────────────────────────────────────────────────┐
-│  bounding boxes ──► bb_to_image_embeddings()    │
-│                     (extract what the VLM        │
-│                      "sees" in that region)      │
-│                                                  │
-│  OCR text ────────► get_text_embedding()         │
-│                     (extract what the VLM        │
-│                      "understands" from the text)│
-└──────────────────────────────────────────────────┘
+## Key Finding
 
-Step 3 — Align: Train the model so the two match up
-┌──────────────────────────────────────────────────┐
-│  For each cell:                                  │
-│    compare image embedding vs text embedding     │
-│    using cosine similarity                       │
-│                                                  │
-│  alignment_loss = how far apart they are         │
-│  total_loss = task_loss + w * alignment_loss     │
-│                                                  │
-│  Backpropagate → model learns to connect what    │
-│  it sees in a cell with what the text says       │
-└──────────────────────────────────────────────────┘
-```
+> **The alignment objective is learnable but does not improve downstream task performance.** Training with a frozen-LM-head bag-of-words probe loss at layer 26 of Qwen3-VL-2B-Instruct reduces the alignment NLL from 10.68 to 6.03 (well below the random floor of 11.93), confirming that the model's visual representations can be pushed toward linguistic decodability. However, exact-match accuracy on CoSyn-400K table QA remains at 0.485 vs. 0.495 for the task-only baseline — within statistical noise (σ ≈ 0.035 at n=200). The downstream task can be solved through a pathway that does not require intermediate visual representations to be linguistically structured.
 
 ---
 
-## Step 1: OCR Detection — `bb_and_text_from_table_image()`
+## Table of Contents
 
-Implemented in `src/ocr_utils.py`. Takes any table image, detects every text region using EasyOCR, and returns bounding boxes `(x1, y1, x2, y2)` paired with the OCR'd text string for each cell. This is the first piece of the pipeline — referred to as `bb_and_text_from_table_image()` in Sameen's pseudocode.
+- [Pipeline Overview](#pipeline-overview)
+- [Step 1: OCR Detection](#step-1-ocr-detection)
+- [Step 2: CLIP Prototype — Validating the Alignment Concept](#step-2-clip-prototype--validating-the-alignment-concept)
+- [Step 3: Qwen3-VL Alignment — Full Implementation and Results](#step-3-qwen3-vl-alignment--full-implementation-and-results)
+  - [Data Preprocessing](#data-preprocessing)
+  - [Training Setup](#training-setup)
+  - [Alignment Loss Formulations](#alignment-loss-formulations)
+  - [Layer Selection](#layer-selection)
+  - [Training Runs and Results](#training-runs-and-results)
+  - [Analysis](#analysis)
+- [Setup and Usage](#setup-and-usage)
+- [Project Structure](#project-structure)
+- [References](#references)
 
-### Synthetic table
+---
+
+## Pipeline Overview
+
+The system operates in three stages:
+
+```
+Stage 1 — OCR Detection
+┌──────────────────────────────────────────────────────┐
+│  Table Image                                         │
+│       │                                              │
+│       ▼                                              │
+│  bb_and_text_from_table_image()   [EasyOCR]          │
+│       │                                              │
+│       ├──► bounding boxes  (x1, y1, x2, y2 per cell) │
+│       └──► OCR text        (string content per cell)  │
+└──────────────────────────────────────────────────────┘
+
+Stage 2 — Embedding Extraction
+┌──────────────────────────────────────────────────────┐
+│  bounding boxes ──► bb_to_image_embeddings()          │
+│                     Maps each bbox to the VLM's       │
+│                     visual token indices, then         │
+│                     extracts hidden states at a        │
+│                     target layer via forward hook      │
+│                                                       │
+│  OCR text ────────► Text hidden states                │
+│                     Run each cell's OCR text through   │
+│                     the VLM's language model (no       │
+│                     image) to get the reference         │
+│                     representation at the same layer    │
+└───────────────────────────────────────────────────────┘
+
+Stage 3 — Alignment Training
+┌───────────────────────────────────────────────────────┐
+│  For each cell in the image:                           │
+│    visual_repr  = mean-pool visual tokens in the bbox  │
+│    text_repr    = precomputed text hidden state         │
+│                                                        │
+│  alignment_loss = distance(visual_repr, text_repr)     │
+│  total_loss     = task_loss + w × alignment_loss        │
+│                                                        │
+│  Backpropagate through the LM layers only              │
+│  (vision encoder + MLP projector stay frozen)           │
+└────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Step 1: OCR Detection
+
+**Implementation:** `src/ocr_utils.py`
+
+The function `bb_and_text_from_table_image()` takes a table image and returns bounding boxes paired with OCR text for every detected cell. It uses [EasyOCR](https://github.com/JaidedAI/EasyOCR) for text detection and recognition.
+
+### Validation on Synthetic Data
+
+A controlled synthetic table with known content was used to verify detection accuracy:
 
 ```bash
 python -m src.ocr_utils
 ```
 
-**Input** — a generated table with known content:
+**Input** — generated table with known ground-truth content:
 
 ![Synthetic table](assets/synthetic_table.png)
 
-**Output** — every cell detected, labeled with its index and extracted text:
+**Output** — all cells detected and labeled with extracted text:
 
 ![Annotated synthetic table](assets/synthetic_annotated.png)
 
-11 detections. All headers (Item, Price, Qty), row labels (Apple, Banana, Orange), and values found.
+11 detections — all headers (Item, Price, Qty), row labels (Apple, Banana, Orange), and numeric values correctly identified.
 
-### Real-world tables
+### Validation on Real-World Tables
 
-Also tested on real table images downloaded from the internet to verify the function works beyond synthetic data.
+The OCR pipeline was tested on real table images to confirm generalization beyond synthetic data.
 
 ```bash
 python -m src.ocr_utils test_images/income_guidelines.png
@@ -79,7 +117,7 @@ python -m src.ocr_utils test_images/income_guidelines.png
 
 ![Annotated income table](assets/income_annotated.png)
 
-27 detections — headers, row numbers, and dollar amounts all found. One OCR quirk: EasyOCR reads "$" as "S" (e.g. "$3,332" → "S3,332"). This is a known EasyOCR limitation with dollar sign characters.
+27 detections — headers, row numbers, and dollar amounts all found. One known EasyOCR limitation: the "$" character is sometimes misread as "S" (e.g., "$3,332" → "S3,332").
 
 ```bash
 python -m src.ocr_utils test_images/grade_distribution.png
@@ -89,229 +127,286 @@ python -m src.ocr_utils test_images/grade_distribution.png
 
 ![Annotated grade table](assets/grade_annotated.png)
 
-11 detections on a clean simple table.
+11 detections on a clean table layout.
 
 ---
 
-## Step 2: CLIP Prototype — Validating the Alignment Idea
+## Step 2: CLIP Prototype — Validating the Alignment Concept
 
-### Why build this?
+**Implementation:** `src/embedding_utils.py`, `src/losses.py`, `src/train.py`, `src/demo.py`
 
-The real pipeline will use Qwen3-VL (a large model that requires GPU infrastructure and integration with Sameen's codebase). Before going through all of that, a quick prototype was built using [CLIP](https://openai.com/research/clip) (a smaller, easy-to-run image-text model by OpenAI) to answer a simple question: **can a model be trained to match a table cell's image with its text?** If the answer is no, there's no point setting up Qwen3-VL.
+### Purpose
 
-### What CLIP does here
+Before building the full Qwen3-VL pipeline (which requires GPU infrastructure and complex integration), a lightweight prototype was built using [CLIP](https://openai.com/research/clip) (Radford et al., 2021) to answer a fundamental question: **can a model be trained to align a table cell's visual representation with its textual content?** If this fails even with CLIP, the approach is unlikely to work with any VLM.
 
-CLIP can convert both images and text into numerical vectors (embeddings). So for each cell detected by the OCR in Step 1, two embeddings are produced:
-- **Image embedding** — crop the cell region from the table image, pass it through CLIP
-- **Text embedding** — take the OCR text string (e.g. "Apple"), pass it through CLIP
+### Method
 
-Now both the image and the text are represented as numbers, and cosine similarity can be used to measure how "close" they are.
+CLIP produces embeddings for both images and text. For each cell detected by OCR:
+- **Image embedding**: crop the cell region from the table image, encode with CLIP's vision encoder
+- **Text embedding**: encode the OCR text string with CLIP's text encoder
 
-### The problem
-
-Out of the box, CLIP scores every image-text pair at roughly ~0.22. It can't tell that the image crop of "Apple" should match the text "Apple" any more than it matches "Banana." This makes sense — CLIP was trained on photos and captions, not tiny crops of table cells.
-
-### The fix
-
-Two small trainable layers (projection heads) were added on top of the frozen CLIP embeddings and trained with a simple rule: **the image of cell N should match the text of cell N, and not match anything else.** After ~20 rounds of training, matched pairs hit 0.999 similarity.
+Two small trainable projection heads were added on top of the frozen CLIP embeddings and trained with a contrastive objective: the image embedding of cell N should be similar to the text embedding of cell N and dissimilar to all other cells.
 
 ### Results
 
-**Before training** — everything looks the same (~0.22), the model can't distinguish any pairs:
+**Before training** — cosine similarity is ~0.22 for all pairs; the model cannot distinguish matched from unmatched:
 
 ![Similarity before](assets/sim_before.png)
 
-**After training** — matched pairs (the diagonal) are now clearly aligned:
+**After training** (~20 epochs) — matched pairs on the diagonal are clearly separated:
 
 ![Similarity after](assets/sim_after.png)
 
-**Training loss:**
+**Training loss convergence:**
 
 ![Training loss](assets/training_loss.png)
 
 | Metric | Before | After |
 |--------|--------|-------|
-| Matched-pair similarity | 0.24 | 0.999 |
-| Retrieval accuracy (image→text) | 55% | 73% |
-| Retrieval accuracy (text→image) | 64% | 82% |
-| Loss | 1.10 | 0.001 |
+| Matched-pair cosine similarity | 0.24 | 0.999 |
+| Image → text retrieval accuracy | 55% | 73% |
+| Text → image retrieval accuracy | 64% | 82% |
+| Contrastive loss | 1.10 | 0.001 |
 
-### Conclusion
+### Takeaway
 
-The alignment concept is validated — a model **can** be trained to connect table cell images with their corresponding text. This prototype is not the final approach though. CLIP uses two separate encoders for images and text, which is why projection heads were needed to bridge them. Qwen3-VL (the real model, from Sameen's [codebase](https://github.com/Patchwork53/VLMs-Need-Words-Public/blob/main/shape_correspond/rep_qwen_squiggles.py)) is a single model where images and text already share the same internal representation space — so the alignment loss can be applied directly without needing extra projection heads.
-
-Implemented in `src/embedding_utils.py`, `src/losses.py`, `src/train.py`, and `src/demo.py`.
+The alignment concept is validated: a model **can** learn to match table cell images with their text. The CLIP prototype required projection heads because CLIP uses separate encoders for vision and text. In contrast, Qwen3-VL is a unified model where images and text share the same transformer layers, so the alignment loss can be applied directly to intermediate hidden states without additional projection layers.
 
 ---
 
-## Step 3: Qwen3-VL Alignment — Implementation & Results
+## Step 3: Qwen3-VL Alignment — Full Implementation and Results
 
-With the CLIP prototype confirming the alignment idea works in principle, the real pipeline was built on Qwen3-VL-2B-Instruct using CoSyn-400K (table split). This section documents the full setup, the diagnostic work that informed the design, and the result we landed on.
+With the CLIP prototype confirming the alignment idea is feasible, the full pipeline was built on **Qwen3-VL-2B-Instruct** using the table split of **CoSyn-400K** (a synthetic table question-answering dataset).
 
-### Data preprocessing — `src/preprocess_cosyn.py`
+### Data Preprocessing
 
-For each CoSyn-table image:
-1. Run EasyOCR → bounding boxes + OCR text per cell.
-2. Pass each cell's OCR text through the Qwen3-VL **language model only** (no image) → extract the hidden state at every LM layer (28 total).
-3. Save bboxes + texts + per-layer text hidden states + image hash to `data/preprocessed/{idx}.pt`.
+**Implementation:** `src/preprocess_cosyn.py`
 
-These `.pt` files become the alignment targets at training time: for each visible cell in an image, we know which pixel region it occupies, what text it contains, and what the LM's hidden representation of that text looks like at every layer. Run once on a GPU to populate `data/preprocessed/` (1,050 images for the experiments below).
+For each CoSyn-table image, the preprocessing pipeline:
+1. Runs EasyOCR to extract bounding boxes and OCR text for every cell
+2. Passes each cell's OCR text through the Qwen3-VL language model (text-only, no image input) to extract hidden states at all 28 LM layers
+3. Saves bounding boxes, OCR text, per-layer text hidden states, and an image hash to `data/preprocessed/{idx}.pt`
 
-### Training setup — `src/train_qwen_cosyn.py`
+These `.pt` files serve as alignment targets during training. For each cell visible in a table image, the training loop knows: which pixel region it occupies, what text it contains, and what the model's text-only representation of that text looks like at every layer. This is run once on GPU before training begins. The current experiments use 1,050 preprocessed images.
 
-Per [Sameen's design directives](https://github.com/Patchwork53/VLMs-Need-Words-Public/blob/main/shape_correspond/rep_qwen_squiggles.py):
+### Training Setup
 
-- **Vision encoder + MLP projector are frozen**; only the LM layers are trainable.
-- Training is on the task objective (next-token CE on table-QA answers) **plus** an auxiliary alignment loss applied to a single intermediate LM layer via a forward hook.
-- `loss = task_loss + alignment_loss_weight * alignment_loss`
+**Implementation:** `src/train_qwen_cosyn.py`
 
-The alignment loss has two implemented formulations (`src/losses.py`):
+The training configuration:
+- **Frozen components:** Vision encoder and MLP projector (only the 28 LM layers are trainable)
+- **Task objective:** Next-token cross-entropy loss on table QA answer generation
+- **Auxiliary objective:** Alignment loss applied at a single intermediate LM layer via a PyTorch forward hook
+- **Combined loss:** `loss = task_loss + alignment_loss_weight × alignment_loss`
+- **Optimizer:** AdamW with cosine learning rate schedule
+- **Infrastructure:** Single-GPU training with Hugging Face Accelerate, gradient accumulation (8 steps), mixed precision (bf16)
 
-- **`mse`** (initial spec): mean-pool visual tokens per cell at layer L, compare against the precomputed text hidden state with raw L2.
-- **`lm_head_bow`** (current spec, per Sameen 2026-05-07): mean-pool visual tokens per cell at layer L, project through the **frozen** LM head, and compute per-token CE against the OCR tokens of that cell (bag-of-words within the cell). The "VLM Needs Words"-style frozen probe — push intermediate visual reps to be linguistically decodable through the unchanged LM head.
+The vision encoder is frozen because the research question is about the LM layers' internal representations — whether training them to be linguistically decodable at intermediate layers helps downstream performance. Freezing the vision encoder isolates this effect.
 
-OCR bboxes are mapped to Qwen3-VL visual token indices via `src/token_map.py` using the patch grid math, so the full image is encoded once (no per-cell crops) and the per-cell visual representation is just a mean-pool of the visual tokens that fall inside that cell's bbox.
+### Alignment Loss Formulations
 
-### Layer sweep — picking where to attach the auxiliary loss
+**Implementation:** `src/losses.py`
 
-The `lm_head_bow` formulation assumes intermediate LM layers encode visual reps that the frozen LM head can partially decode. To find which layer (`scripts/calibrate_alignment.py --alignment-loss-mode lm_head_bow --alignment-layer L`), the per-cell NLL was measured on 20 CoSyn-table samples (~191 cells) with the **untrained** model:
+Two alignment loss formulations were implemented and tested:
 
-| Layer | mean NLL | min  | Δ vs random (11.93) |
-|------:|---------:|-----:|---------------:|
-| 8     | 14.94    | 9.08 | +3.01 |
-| 12    | 13.09    | 7.43 | +1.16 |
-| 16    | 12.23    | 5.68 | +0.30 |
-| 20    | 12.59    | 7.84 | +0.66 |
-| 24    | 11.62    | 5.94 | −0.31 |
-| **26**| **10.54**| 4.55 | **−1.39** |
-| 27    | 32.60    | 2.23 | +20.67 |
+**1. MSE (Mean Squared Error)**
+- Mean-pool the visual tokens within each cell's bounding box at layer L
+- Compare against the precomputed text hidden state at the same layer using L2 distance
+- Simple and direct, but operates in the raw hidden-state space where distances may not be semantically meaningful
 
-Random NLL is `log(151643) ≈ 11.93`. Only **layer 26** has a meaningfully below-random baseline, meaning the frozen LM head can already decode layer-26 visual reps non-trivially. Layers 8–20 start at or above random, so attaching the loss there asks the model to learn the alignment from scratch. Layer 27 is anomalous because final hiddens encode next-token predictions rather than OCR content (the model's "what comes after this visual token" pathway happens to give some tokens very low NLL on coincidental matches).
+**2. LM Head Bag-of-Words (`lm_head_bow`)**
+- Mean-pool the visual tokens within each cell's bounding box at layer L
+- Project the pooled representation through the model's **frozen** language model head (the same linear layer used for next-token prediction)
+- Compute cross-entropy loss against the OCR tokens of that cell (treated as a bag of words — order-independent)
+- Inspired by the LatentLens and VLMs Need Words findings: if intermediate hidden states occupy a shared text-image space, the frozen LM head should be able to decode them into text. This loss directly trains for that property.
 
-### Training runs
+The `lm_head_bow` formulation has a clear interpretability advantage: the alignment NLL can be compared against the random baseline (`log(vocab_size) = log(151643) ≈ 11.93` nats) to measure whether the loss is doing anything meaningful.
 
-Each run uses 200-item held-out eval (`scripts/eval_table_metrics.py`, deterministic slice), exact-match against gold-truth answers and token-level F1.
+### Layer Selection
 
-| Run | Alignment | Weight | Layer | Notes |
-|---|---|---:|---:|---|
-| Base | none | — | — | Zero-shot Qwen3-VL-2B-Instruct |
-| Run1 | MSE (raw L2) | 1e-5 | 16 | Original spec, ran 2026-04-27 |
-| Run2 | none (task-only) | 0 | — | Baseline for the auxiliary loss, ran 2026-04-29 |
-| Run4 | lm_head_bow (frozen-probe CE) | 0.04 | 26 | `--aligned_only` filter, ran 2026-05-14 |
+**Implementation:** `scripts/calibrate_alignment.py`
 
-The `--aligned_only` flag was added because only 1,050 of ~416k expanded train items have matching `.pt` data (~2.3% sparsity). Without it, ~98% of micro-batches contribute zero alignment gradient. With it, every batch contributes (~9,330 items, every batch has alignment). Val split stays unfiltered so EM is comparable across runs.
+The `lm_head_bow` loss assumes some LM layers already encode visual information in a partially text-decodable format. A layer sweep was conducted on 20 CoSyn-table samples (~191 cells) to measure the per-cell NLL at each layer using the **untrained** model:
 
-### Results
+| Layer | Mean NLL | Min NLL | Δ vs. Random (11.93) |
+|------:|---------:|--------:|---------------------:|
+| 8     | 14.94    | 9.08    | +3.01                |
+| 12    | 13.09    | 7.43    | +1.16                |
+| 16    | 12.23    | 5.68    | +0.30                |
+| 20    | 12.59    | 7.84    | +0.66                |
+| 24    | 11.62    | 5.94    | −0.31                |
+| **26**| **10.54**| **4.55**| **−1.39**            |
+| 27    | 32.60    | 2.23    | +20.67               |
 
-| Run | EM (200) | Token F1 (200) |
-|---|---:|---:|
-| Base | 0.000 | 0.051 |
-| Run1 (task + MSE, w=1e-5, layer 16) | 0.500 | 0.586 |
-| Run2 (task-only) | 0.495 | 0.584 |
-| **Run4 (task + lm_head_bow, w=0.04, layer 26, aligned_only)** | **0.485** | **0.573** |
+**Layer 26** was selected as the alignment target. It is the only layer where the frozen LM head can decode visual representations meaningfully below the random floor — the untrained model already achieves a mean NLL of 10.54 (1.39 nats below random). This means the LM head can partially read the visual hidden states at this layer even without any alignment training, making it a natural anchor point for the auxiliary loss.
 
-**The auxiliary alignment loss is *learnable* but does not *improve* downstream EM.** Run4's alignment loss dropped from 10.68 (random) → 6.03 over 2 epochs (~4.7 nats below the random floor — a real signal the LM head is decoding the visual reps better than at init), but the held-out EM is within statistical noise of both run1 (MSE-aligned) and run2 (task-only). σ at n=200 is ~0.035, so the −0.015 EM gap between run4 and run1 is well inside one standard deviation.
+Layers 8–20 start at or above the random baseline, meaning the LM head cannot decode visual reps at all — attaching the alignment loss there would require the model to learn the alignment entirely from scratch. Layer 27 is anomalous: the final layer's hidden states encode next-token predictions rather than cell content, producing artificially low NLL on coincidental token matches.
 
-Why this is a meaningful negative result: the model can do CoSyn table QA via a pathway that does **not** require layer-26 visual reps to be linguistically decodable. Pushing them to be decodable is achievable but orthogonal to the downstream task on this dataset/model. The headline finding for the auxiliary loss strategy is therefore: *learnable ≠ useful*.
+### Training Runs and Results
 
-Two confounds worth flagging in any follow-up:
+**Evaluation:** `scripts/eval_table_metrics.py` — 200-item held-out set, exact-match (EM) against gold answers and token-level F1.
 
-1. **Smaller train set under `--aligned_only`.** Run4 saw 9,330 unique items × 3 epochs vs Run2's ~416k × 3 epochs. A clean A/B (run5 = task-only on the same 9,330 items) would isolate "alignment hurts" vs "smaller dataset hurts."
-2. **Layer choice was optimized for the *probe*, not the *task*.** Layer 26 has the strongest frozen-decoding signal, but it's also where visual reps are already mostly linguistic. An earlier layer (e.g., 20–22) — where the visual→linguistic transition is mid-flight — might be more impactful for downstream EM even though the frozen probe is noisier there.
+| Run | Configuration | Alignment Weight | Layer | Train Items |
+|-----|--------------|----------------:|------:|------------:|
+| Base | Zero-shot Qwen3-VL-2B-Instruct (no fine-tuning) | — | — | — |
+| Run 1 | Task + MSE alignment | 1e-5 | 16 | ~416K |
+| Run 2 | Task-only (no alignment) | 0 | — | ~416K |
+| Run 4 | Task + `lm_head_bow` alignment | 0.04 | 26 | 9,330 |
 
-### Engineering notes from the experiments
+**Note on Run 4's training set:** Only 1,050 of the ~416K training items have preprocessed alignment data (~0.25%). Without filtering, ~98% of mini-batches contribute zero alignment gradient. The `--aligned_only` flag restricts training to the 9,330 items that have alignment targets (each image appears in multiple QA pairs), ensuring every batch contributes alignment signal. The held-out evaluation set is unfiltered, so EM scores are comparable across all runs.
 
-- Run3 (2026-05-13, single-GPU `lm_head_bow` at layer 16, w=0.01) **died silently at 12h** because stdout was block-buffered through bash redirect and the final traceback never reached disk. The fix is `PYTHONUNBUFFERED=1` + `python -u` + `tee` in the launch path (`scripts/launch_align.sh`).
-- The training script's prior loss-logging code accumulated per micro-batch but divided by `log_every` (counts optimizer steps), producing values 8× the true per-forward mean at `grad_accum_steps=8`. Fixed in the same commit as the safeguards. Older run logs (pre-fix) need mental rescaling.
-- Multi-GPU dataset construction reproducibly OOMs at `--num_processes ≥ 2` during the qa_pair expansion phase. Stuck to single GPU.
-- The full safeguard stack (mid-epoch `accelerator.save_state` + `--resume_from` + watchdog + line-buffered logs) was validated end-to-end via a smoke run that included a deliberate SIGTERM and resume from checkpoint. Training continues at the saved step with task-loss continuity.
+#### Results
 
-Implemented in:
-- `src/preprocess_cosyn.py` — OCR + per-layer text hidden state extraction
-- `src/train_qwen_cosyn.py` — training loop, alignment hook, mid-epoch saves, resume
-- `src/token_map.py` — OCR bbox → visual token index mapping
-- `src/losses.py` — `compute_lm_head_bow_loss` (and the legacy MSE / cosine / contrastive losses from the CLIP prototype)
-- `scripts/calibrate_alignment.py` — weight calibration + layer sweep diagnostic
-- `scripts/eval_table_metrics.py` — EM/F1 eval on the 200-item held-out slice
-- `scripts/launch_align.sh` — survivable-launch wrapper
-- `scripts/watchdog.sh` — process + log watchdog
+| Run | EM (n=200) | Token F1 (n=200) |
+|-----|----------:|----------------:|
+| Base (zero-shot) | 0.000 | 0.051 |
+| Run 1 (task + MSE, w=1e-5, layer 16) | 0.500 | 0.586 |
+| Run 2 (task-only baseline) | 0.495 | 0.584 |
+| **Run 4 (task + lm_head_bow, w=0.04, layer 26)** | **0.485** | **0.573** |
+
+#### Alignment Loss Trajectory (Run 4)
+
+The alignment loss dropped from 10.68 → 6.03 over 2 epochs, confirming the objective is learnable — the model's layer-26 visual representations moved ~4.7 nats below the random floor, meaning the frozen LM head can decode cell content from visual hidden states significantly better than chance after training.
+
+### Analysis
+
+**The alignment objective is achievable but orthogonal to the downstream task.** The −0.015 EM gap between Run 4 (0.485) and Run 1 (0.500) is well within one standard deviation (σ ≈ 0.035 at n=200). All three fine-tuned runs — with MSE alignment, with LM-head alignment, and without any alignment — perform comparably.
+
+This is a meaningful negative result: it demonstrates that Qwen3-VL-2B can solve CoSyn table QA through an internal pathway that does **not** require intermediate visual representations to be linguistically decodable. Forcing them to be decodable (which the model can learn to do) neither helps nor significantly hurts. **Learnable ≠ useful.**
+
+#### Confounds and Candidate Next Steps
+
+Two confounds should be addressed before drawing stronger conclusions:
+
+1. **Dataset size imbalance.** Run 4 trained on 9,330 unique items (with `--aligned_only`) while Run 2 trained on ~416K items. A controlled comparison (Run 5 = task-only on the same 9,330 items) would isolate whether the EM difference is due to the alignment loss or the smaller training set.
+
+2. **Layer selection optimized for the probe, not the task.** Layer 26 was chosen because the frozen LM head can already decode visual reps there. But this also means those representations are already mostly linguistic — the alignment loss may be reinforcing something the model already does. An earlier layer (e.g., 20–22), where the visual-to-linguistic transition is still in progress, might be more impactful for downstream EM even though the frozen probe is noisier there.
+
+3. **Alignment data coverage.** Expanding from 1,050 to 10,000+ preprocessed images would allow training without the `--aligned_only` filter, maintaining full-data fidelity while still providing alignment signal.
+
+### Engineering Notes
+
+- **Run 3 failure (silent death):** A single-GPU `lm_head_bow` run at layer 16 died silently after 12 hours because stdout was block-buffered through a bash redirect, and the final traceback never reached disk. Fixed by enforcing `PYTHONUNBUFFERED=1` + `python -u` + piping through `tee` in the launch script.
+- **Loss-logging bug:** The original loss accumulation logic divided by `log_every` (which counts optimizer steps) but accumulated per micro-batch, producing values 8× the true per-forward mean at `grad_accum_steps=8`. Fixed; older run logs (pre-fix) need manual rescaling.
+- **Multi-GPU OOM:** Dataset construction reproducibly OOMs with `--num_processes ≥ 2` during the QA-pair expansion phase. All runs used single-GPU training.
+- **Checkpoint and recovery:** Mid-epoch checkpointing via `accelerator.save_state`, `--resume_from` flag, and a process watchdog (`scripts/watchdog.sh`) were validated end-to-end with a deliberate SIGTERM + resume cycle. Training continues at the saved step with loss continuity.
 
 ---
 
-## Setup
+## Setup and Usage
+
+### Prerequisites
+
+- Python 3.10+
+- CUDA-capable GPU (required for Qwen3-VL training; CLIP prototype runs on CPU)
+- ~10 GB disk space for model weights and preprocessed data
+
+### Installation
 
 ```bash
-git clone <this-repo>
+git clone https://github.com/rpatel0022/SeniorResearchProject.git
 cd SeniorResearchProject
 python -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
 ```
 
-## Run
+### Running the OCR Pipeline
 
 ```bash
-# OCR on synthetic table
+# OCR on the built-in synthetic table
 python -m src.ocr_utils
 
-# OCR on a real image
+# OCR on any table image
 python -m src.ocr_utils path/to/table.png
+```
 
-# Full prototype pipeline (OCR → CLIP embeddings → alignment training)
+### Running the CLIP Prototype
+
+```bash
+# Full prototype pipeline: OCR → CLIP embeddings → contrastive alignment training
 python -m src.demo --epochs 50
+```
 
-# Tests (6 OCR tests + embedding/loss/training tests)
+### Running the Qwen3-VL Pipeline
+
+```bash
+# Step 1: Preprocess CoSyn-400K table images (run once on GPU)
+python -m src.preprocess_cosyn
+
+# Step 2: Train with alignment loss
+bash scripts/launch_align.sh
+
+# Step 3: Evaluate on held-out set
+python scripts/eval_table_metrics.py --checkpoint_dir <path>
+```
+
+### Running Tests
+
+```bash
+# Full test suite (OCR, embeddings, loss functions, training loop)
 python -m pytest tests/ -v -s
 ```
+
+---
 
 ## Project Structure
 
 ```
 src/
-├── ocr_utils.py          # bb_and_text_from_table_image() — OCR function (Step 1)
-├── synthetic_data.py     # Generates sample table images for testing
-├── embedding_utils.py    # CLIP embedding extraction (Step 2 prototype)
-├── losses.py             # Alignment loss functions (cosine/contrastive/MSE/lm_head_bow)
-├── train.py              # Projection head training loop (Step 2 prototype)
-├── demo.py               # End-to-end demo tying Steps 1 + 2 together
-├── preprocess_cosyn.py   # CoSyn-400K preprocessing → data/preprocessed/*.pt (Step 3)
-├── token_map.py          # OCR bbox → Qwen3-VL visual token indices (Step 3)
-└── train_qwen_cosyn.py   # Qwen3-VL training loop with auxiliary alignment loss (Step 3)
+├── ocr_utils.py            # bb_and_text_from_table_image() — EasyOCR cell detection
+├── synthetic_data.py        # Generates sample table images for testing
+├── embedding_utils.py       # CLIP embedding extraction (prototype)
+├── losses.py                # Alignment losses: cosine, contrastive, MSE, lm_head_bow
+├── train.py                 # CLIP projection head training loop (prototype)
+├── demo.py                  # End-to-end CLIP prototype demo
+├── preprocess_cosyn.py      # CoSyn-400K → per-image bboxes, OCR text, layer-wise hidden states
+├── token_map.py             # OCR bounding box → Qwen3-VL visual token index mapping
+└── train_qwen_cosyn.py      # Qwen3-VL fine-tuning with auxiliary alignment loss
 
 scripts/
-├── calibrate_alignment.py   # Weight calibration + layer-sweep diagnostic
-├── eval_table_metrics.py    # EM / token-F1 eval on 200-item held-out slice
-├── launch_align.sh          # Survivable-launch wrapper (PYTHONUNBUFFERED + nohup + tee)
-└── watchdog.sh              # PID + log-staleness watchdog with forensic alerts
+├── calibrate_alignment.py   # Layer sweep + alignment weight calibration
+├── eval_table_metrics.py    # EM / token-F1 evaluation on held-out split
+├── launch_align.sh          # Launch wrapper (unbuffered IO, nohup, tee)
+└── watchdog.sh              # Process + log-staleness watchdog
 
 tests/
-├── test_ocr.py           # OCR detection tests
-├── test_embeddings.py    # Embedding extraction tests
-├── test_loss.py          # Loss computation tests
-└── test_train.py         # Training loop tests
+├── test_ocr.py              # OCR detection tests
+├── test_embeddings.py       # Embedding extraction tests
+├── test_loss.py             # Loss computation tests
+└── test_train.py            # Training loop tests
+
+assets/                      # Figures for this README
+data/preprocessed/           # Precomputed alignment targets (.pt files, gitignored)
 ```
+
+---
 
 ## Progress
 
-**Done:**
-- [x] OCR pipeline — `bb_and_text_from_table_image()` tested on synthetic + real-world images
-- [x] CLIP-based proof-of-concept — standalone prototype proving alignment training works end-to-end
-- [x] OCR → Qwen3-VL token index mapping (`src/token_map.py`)
-- [x] CoSyn-400K preprocessing pipeline — produces per-image bboxes, OCR text, and per-layer text hidden states (`src/preprocess_cosyn.py`)
-- [x] Qwen3-VL training loop with vision+MLP frozen, single-hook alignment loss (`src/train_qwen_cosyn.py`)
-- [x] Auxiliary loss formulations — raw L2 (run1), `lm_head_bow` per Sameen's May 7 proposal (run4)
-- [x] Three-eval comparison (base / task-only / task+align) on 200-item held-out
-- [x] Layer-sweep diagnostic — identified layer 26 as the only Qwen3-VL-2B LM layer where the frozen LM head decodes visual reps non-trivially
-- [x] Run4 with `lm_head_bow` at layer 26 — alignment loss learnable (10.68 → 6.03) but EM does not improve vs task-only baseline
-- [x] Engineering safeguards — mid-epoch checkpointing, `--resume_from`, generic watchdog, line-buffered logs (post run3 silent-death)
+### Completed
+- [x] OCR pipeline (`bb_and_text_from_table_image`) — validated on synthetic and real-world table images
+- [x] CLIP-based proof-of-concept — demonstrated alignment training is feasible end-to-end
+- [x] Bounding box → Qwen3-VL visual token index mapping (`src/token_map.py`)
+- [x] CoSyn-400K preprocessing pipeline — per-image bboxes, OCR text, 28-layer text hidden states
+- [x] Qwen3-VL fine-tuning loop with frozen vision encoder, single-layer alignment hook
+- [x] Two alignment loss formulations — raw L2/MSE and frozen-LM-head bag-of-words probe
+- [x] Layer sweep diagnostic — identified layer 26 as the optimal alignment target for Qwen3-VL-2B
+- [x] Four-run experimental comparison: zero-shot, task+MSE, task-only, task+lm_head_bow
+- [x] Negative result documented: alignment is learnable (NLL 10.68 → 6.03) but does not improve downstream EM
+- [x] Engineering safeguards — mid-epoch checkpointing, `--resume_from`, watchdog, line-buffered logging
 
-**Open questions / candidate next steps:**
-- [ ] Run5 = task-only on the 9,330 aligned items — isolates the dataset-size confound in the run4 vs run2 comparison
-- [ ] Sweep alignment layer with `--aligned_only` (e.g., layers 20–22) — frozen-probe NLL ≠ task-helpfulness; an earlier layer might transfer to EM even with a noisier baseline
-- [ ] Expand preprocessed alignment data 1,050 → 10k images — would let us re-run without `--aligned_only` and keep full-data fidelity
+### Open Questions / Next Steps
+- [ ] Run 5: task-only on 9,330 aligned items — isolate dataset-size confound vs. Run 4
+- [ ] Sweep alignment layer with `--aligned_only` (layers 20–22) — test whether earlier-layer alignment transfers better to downstream EM
+- [ ] Expand preprocessed data from 1,050 → 10,000+ images — enable full-dataset training with alignment signal
+
+---
 
 ## References
 
-- [VLMs Need Words](https://arxiv.org/abs/2604.02486) — Shahgir et al. Why VLMs fail on unnamed visual entities
-- [LatentLens](https://arxiv.org/abs/2602.00462) — Krojer et al. Mid-layer hidden states as shared text-image spaces
-- [bb_to_image_embeddings reference code](https://github.com/Patchwork53/VLMs-Need-Words-Public/blob/main/shape_correspond/rep_qwen_squiggles.py)
+1. **VLMs Need Words** — Shahgir et al. (2025). *Why Vision-Language Models Fail on Unnamed Visual Entities.* [arXiv:2604.02486](https://arxiv.org/abs/2604.02486)
+2. **LatentLens** — Krojer et al. (2024). *Probing Intermediate Representations of VLMs.* [arXiv:2602.00462](https://arxiv.org/abs/2602.00462)
+3. **CLIP** — Radford et al. (2021). *Learning Transferable Visual Models From Natural Language Supervision.* OpenAI.
+4. **Qwen2.5-VL / Qwen3-VL** — Bai et al. (2025). *Qwen2.5-VL Technical Report.* Alibaba Group.
+5. **CoSyn** — Synthetic table QA dataset used for training and evaluation.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Table-Text Alignment for VLMs
 
-**Cell-level contrastive alignment loss that forces VLMs to align their visual representations of table regions with OCR-extracted text — giving the model semantic anchors for every cell.**
+**Cell-level alignment loss that pushes a VLM's visual representations of table regions toward the corresponding OCR text — giving the model semantic anchors for every cell.**
+
+> **Headline result (run4, May 2026):** with the `lm_head_bow` auxiliary loss (frozen-LM-head probe per Sameen's "VLM Needs Words"-inspired proposal) at layer 26 of Qwen3-VL-2B-Instruct, the alignment objective **is learnable** (NLL 10.68 → 6.03, well below the random floor of 11.93) — but downstream **EM on CoSyn-400K table QA does not improve** (0.485 vs 0.495 task-only baseline, within statistical noise at n=200). The auxiliary objective is achievable but appears orthogonal to the downstream task on this dataset/model. See [Step 3](#step-3-qwen3-vl-alignment--implementation--results) for the full table and discussion.
 
 ---
 
@@ -142,6 +144,100 @@ Implemented in `src/embedding_utils.py`, `src/losses.py`, `src/train.py`, and `s
 
 ---
 
+## Step 3: Qwen3-VL Alignment — Implementation & Results
+
+With the CLIP prototype confirming the alignment idea works in principle, the real pipeline was built on Qwen3-VL-2B-Instruct using CoSyn-400K (table split). This section documents the full setup, the diagnostic work that informed the design, and the result we landed on.
+
+### Data preprocessing — `src/preprocess_cosyn.py`
+
+For each CoSyn-table image:
+1. Run EasyOCR → bounding boxes + OCR text per cell.
+2. Pass each cell's OCR text through the Qwen3-VL **language model only** (no image) → extract the hidden state at every LM layer (28 total).
+3. Save bboxes + texts + per-layer text hidden states + image hash to `data/preprocessed/{idx}.pt`.
+
+These `.pt` files become the alignment targets at training time: for each visible cell in an image, we know which pixel region it occupies, what text it contains, and what the LM's hidden representation of that text looks like at every layer. Run once on a GPU to populate `data/preprocessed/` (1,050 images for the experiments below).
+
+### Training setup — `src/train_qwen_cosyn.py`
+
+Per [Sameen's design directives](https://github.com/Patchwork53/VLMs-Need-Words-Public/blob/main/shape_correspond/rep_qwen_squiggles.py):
+
+- **Vision encoder + MLP projector are frozen**; only the LM layers are trainable.
+- Training is on the task objective (next-token CE on table-QA answers) **plus** an auxiliary alignment loss applied to a single intermediate LM layer via a forward hook.
+- `loss = task_loss + alignment_loss_weight * alignment_loss`
+
+The alignment loss has two implemented formulations (`src/losses.py`):
+
+- **`mse`** (initial spec): mean-pool visual tokens per cell at layer L, compare against the precomputed text hidden state with raw L2.
+- **`lm_head_bow`** (current spec, per Sameen 2026-05-07): mean-pool visual tokens per cell at layer L, project through the **frozen** LM head, and compute per-token CE against the OCR tokens of that cell (bag-of-words within the cell). The "VLM Needs Words"-style frozen probe — push intermediate visual reps to be linguistically decodable through the unchanged LM head.
+
+OCR bboxes are mapped to Qwen3-VL visual token indices via `src/token_map.py` using the patch grid math, so the full image is encoded once (no per-cell crops) and the per-cell visual representation is just a mean-pool of the visual tokens that fall inside that cell's bbox.
+
+### Layer sweep — picking where to attach the auxiliary loss
+
+The `lm_head_bow` formulation assumes intermediate LM layers encode visual reps that the frozen LM head can partially decode. To find which layer (`scripts/calibrate_alignment.py --alignment-loss-mode lm_head_bow --alignment-layer L`), the per-cell NLL was measured on 20 CoSyn-table samples (~191 cells) with the **untrained** model:
+
+| Layer | mean NLL | min  | Δ vs random (11.93) |
+|------:|---------:|-----:|---------------:|
+| 8     | 14.94    | 9.08 | +3.01 |
+| 12    | 13.09    | 7.43 | +1.16 |
+| 16    | 12.23    | 5.68 | +0.30 |
+| 20    | 12.59    | 7.84 | +0.66 |
+| 24    | 11.62    | 5.94 | −0.31 |
+| **26**| **10.54**| 4.55 | **−1.39** |
+| 27    | 32.60    | 2.23 | +20.67 |
+
+Random NLL is `log(151643) ≈ 11.93`. Only **layer 26** has a meaningfully below-random baseline, meaning the frozen LM head can already decode layer-26 visual reps non-trivially. Layers 8–20 start at or above random, so attaching the loss there asks the model to learn the alignment from scratch. Layer 27 is anomalous because final hiddens encode next-token predictions rather than OCR content (the model's "what comes after this visual token" pathway happens to give some tokens very low NLL on coincidental matches).
+
+### Training runs
+
+Each run uses 200-item held-out eval (`scripts/eval_table_metrics.py`, deterministic slice), exact-match against gold-truth answers and token-level F1.
+
+| Run | Alignment | Weight | Layer | Notes |
+|---|---|---:|---:|---|
+| Base | none | — | — | Zero-shot Qwen3-VL-2B-Instruct |
+| Run1 | MSE (raw L2) | 1e-5 | 16 | Original spec, ran 2026-04-27 |
+| Run2 | none (task-only) | 0 | — | Baseline for the auxiliary loss, ran 2026-04-29 |
+| Run4 | lm_head_bow (frozen-probe CE) | 0.04 | 26 | `--aligned_only` filter, ran 2026-05-14 |
+
+The `--aligned_only` flag was added because only 1,050 of ~416k expanded train items have matching `.pt` data (~2.3% sparsity). Without it, ~98% of micro-batches contribute zero alignment gradient. With it, every batch contributes (~9,330 items, every batch has alignment). Val split stays unfiltered so EM is comparable across runs.
+
+### Results
+
+| Run | EM (200) | Token F1 (200) |
+|---|---:|---:|
+| Base | 0.000 | 0.051 |
+| Run1 (task + MSE, w=1e-5, layer 16) | 0.500 | 0.586 |
+| Run2 (task-only) | 0.495 | 0.584 |
+| **Run4 (task + lm_head_bow, w=0.04, layer 26, aligned_only)** | **0.485** | **0.573** |
+
+**The auxiliary alignment loss is *learnable* but does not *improve* downstream EM.** Run4's alignment loss dropped from 10.68 (random) → 6.03 over 2 epochs (~4.7 nats below the random floor — a real signal the LM head is decoding the visual reps better than at init), but the held-out EM is within statistical noise of both run1 (MSE-aligned) and run2 (task-only). σ at n=200 is ~0.035, so the −0.015 EM gap between run4 and run1 is well inside one standard deviation.
+
+Why this is a meaningful negative result: the model can do CoSyn table QA via a pathway that does **not** require layer-26 visual reps to be linguistically decodable. Pushing them to be decodable is achievable but orthogonal to the downstream task on this dataset/model. The headline finding for the auxiliary loss strategy is therefore: *learnable ≠ useful*.
+
+Two confounds worth flagging in any follow-up:
+
+1. **Smaller train set under `--aligned_only`.** Run4 saw 9,330 unique items × 3 epochs vs Run2's ~416k × 3 epochs. A clean A/B (run5 = task-only on the same 9,330 items) would isolate "alignment hurts" vs "smaller dataset hurts."
+2. **Layer choice was optimized for the *probe*, not the *task*.** Layer 26 has the strongest frozen-decoding signal, but it's also where visual reps are already mostly linguistic. An earlier layer (e.g., 20–22) — where the visual→linguistic transition is mid-flight — might be more impactful for downstream EM even though the frozen probe is noisier there.
+
+### Engineering notes from the experiments
+
+- Run3 (2026-05-13, single-GPU `lm_head_bow` at layer 16, w=0.01) **died silently at 12h** because stdout was block-buffered through bash redirect and the final traceback never reached disk. The fix is `PYTHONUNBUFFERED=1` + `python -u` + `tee` in the launch path (`scripts/launch_align.sh`).
+- The training script's prior loss-logging code accumulated per micro-batch but divided by `log_every` (counts optimizer steps), producing values 8× the true per-forward mean at `grad_accum_steps=8`. Fixed in the same commit as the safeguards. Older run logs (pre-fix) need mental rescaling.
+- Multi-GPU dataset construction reproducibly OOMs at `--num_processes ≥ 2` during the qa_pair expansion phase. Stuck to single GPU.
+- The full safeguard stack (mid-epoch `accelerator.save_state` + `--resume_from` + watchdog + line-buffered logs) was validated end-to-end via a smoke run that included a deliberate SIGTERM and resume from checkpoint. Training continues at the saved step with task-loss continuity.
+
+Implemented in:
+- `src/preprocess_cosyn.py` — OCR + per-layer text hidden state extraction
+- `src/train_qwen_cosyn.py` — training loop, alignment hook, mid-epoch saves, resume
+- `src/token_map.py` — OCR bbox → visual token index mapping
+- `src/losses.py` — `compute_lm_head_bow_loss` (and the legacy MSE / cosine / contrastive losses from the CLIP prototype)
+- `scripts/calibrate_alignment.py` — weight calibration + layer sweep diagnostic
+- `scripts/eval_table_metrics.py` — EM/F1 eval on the 200-item held-out slice
+- `scripts/launch_align.sh` — survivable-launch wrapper
+- `scripts/watchdog.sh` — process + log watchdog
+
+---
+
 ## Setup
 
 ```bash
@@ -175,9 +271,18 @@ src/
 ├── ocr_utils.py          # bb_and_text_from_table_image() — OCR function (Step 1)
 ├── synthetic_data.py     # Generates sample table images for testing
 ├── embedding_utils.py    # CLIP embedding extraction (Step 2 prototype)
-├── losses.py             # Alignment loss functions (Step 2 prototype)
+├── losses.py             # Alignment loss functions (cosine/contrastive/MSE/lm_head_bow)
 ├── train.py              # Projection head training loop (Step 2 prototype)
-└── demo.py               # End-to-end demo tying Steps 1 + 2 together
+├── demo.py               # End-to-end demo tying Steps 1 + 2 together
+├── preprocess_cosyn.py   # CoSyn-400K preprocessing → data/preprocessed/*.pt (Step 3)
+├── token_map.py          # OCR bbox → Qwen3-VL visual token indices (Step 3)
+└── train_qwen_cosyn.py   # Qwen3-VL training loop with auxiliary alignment loss (Step 3)
+
+scripts/
+├── calibrate_alignment.py   # Weight calibration + layer-sweep diagnostic
+├── eval_table_metrics.py    # EM / token-F1 eval on 200-item held-out slice
+├── launch_align.sh          # Survivable-launch wrapper (PYTHONUNBUFFERED + nohup + tee)
+└── watchdog.sh              # PID + log-staleness watchdog with forensic alerts
 
 tests/
 ├── test_ocr.py           # OCR detection tests
@@ -186,19 +291,24 @@ tests/
 └── test_train.py         # Training loop tests
 ```
 
-Sameen's `bb_to_image_embeddings` using Qwen3-VL is in [his repo](https://github.com/Patchwork53/VLMs-Need-Words-Public/blob/main/shape_correspond/rep_qwen_squiggles.py). The next step is integrating the OCR function from this repo with his pipeline.
-
 ## Progress
 
 **Done:**
-- [x] Implemented `bb_and_text_from_table_image()` — tested on synthetic + real-world images
-- [x] Studied Sameen's `bb_to_image_embeddings()` — [reference code](https://github.com/Patchwork53/VLMs-Need-Words-Public/blob/main/shape_correspond/rep_qwen_squiggles.py) that extracts Qwen3-VL hidden states for bounding box regions
-- [x] Built CLIP-based proof-of-concept — standalone prototype proving alignment training works end-to-end
+- [x] OCR pipeline — `bb_and_text_from_table_image()` tested on synthetic + real-world images
+- [x] CLIP-based proof-of-concept — standalone prototype proving alignment training works end-to-end
+- [x] OCR → Qwen3-VL token index mapping (`src/token_map.py`)
+- [x] CoSyn-400K preprocessing pipeline — produces per-image bboxes, OCR text, and per-layer text hidden states (`src/preprocess_cosyn.py`)
+- [x] Qwen3-VL training loop with vision+MLP frozen, single-hook alignment loss (`src/train_qwen_cosyn.py`)
+- [x] Auxiliary loss formulations — raw L2 (run1), `lm_head_bow` per Sameen's May 7 proposal (run4)
+- [x] Three-eval comparison (base / task-only / task+align) on 200-item held-out
+- [x] Layer-sweep diagnostic — identified layer 26 as the only Qwen3-VL-2B LM layer where the frozen LM head decodes visual reps non-trivially
+- [x] Run4 with `lm_head_bow` at layer 26 — alignment loss learnable (10.68 → 6.03) but EM does not improve vs task-only baseline
+- [x] Engineering safeguards — mid-epoch checkpointing, `--resume_from`, generic watchdog, line-buffered logs (post run3 silent-death)
 
-**Next:**
-- [ ] `get_text_embedding()` — extract contextualized hidden states from Qwen3-VL's LLM backbone at mid-layers (8-16), informed by [LatentLens](https://arxiv.org/abs/2602.00462)
-- [ ] Integrate OCR function into Sameen's Qwen3-VL pipeline
-- [ ] Evaluation on real table datasets (PubTabNet)
+**Open questions / candidate next steps:**
+- [ ] Run5 = task-only on the 9,330 aligned items — isolates the dataset-size confound in the run4 vs run2 comparison
+- [ ] Sweep alignment layer with `--aligned_only` (e.g., layers 20–22) — frozen-probe NLL ≠ task-helpfulness; an earlier layer might transfer to EM even with a noisier baseline
+- [ ] Expand preprocessed alignment data 1,050 → 10k images — would let us re-run without `--aligned_only` and keep full-data fidelity
 
 ## References
 

--- a/scripts/calibrate_alignment.py
+++ b/scripts/calibrate_alignment.py
@@ -1,0 +1,245 @@
+"""
+Calibrate alignment_loss_weight per issue #5.
+
+Goal: find w such that  w * align_loss  approx  0.1 * task_loss
+on items where alignment data is present.
+
+Approach:
+  1. Load N preprocessed .pt files
+  2. Stream CoSyn-400K and grab the matching (image, qa_pairs) by row_id
+  3. Run a forward pass through Qwen3-VL with the alignment hook on layer L
+  4. Compute task CE loss (on answer tokens) and align MSE loss (mean-pool +
+     fp32, matching compute_alignment_loss exactly)
+  5. Average over items, print the ratio and recommended w
+
+Run on GPU 0:
+  CUDA_VISIBLE_DEVICES=0 python -m scripts.calibrate_alignment --num-samples 20
+"""
+
+import argparse
+import glob
+import statistics
+
+import torch
+import torch.nn.functional as F
+
+from transformers import AutoProcessor, Qwen3VLForConditionalGeneration
+from datasets import load_dataset
+from qwen_vl_utils import process_vision_info
+
+from src.train_qwen_cosyn import _image_hash
+from src.token_map import (
+    get_processed_resolution,
+    scale_bbox,
+    find_qwen3vl_image_tokens,
+)
+
+
+def main(num_samples: int, alignment_layer: int, max_seq_len: int) -> None:
+    device = torch.device("cuda")
+    model_name = "Qwen/Qwen3-VL-2B-Instruct"
+
+    print(f"[calib] loading processor + model ({model_name})...")
+    processor = AutoProcessor.from_pretrained(model_name, trust_remote_code=True)
+    model = Qwen3VLForConditionalGeneration.from_pretrained(
+        model_name,
+        dtype=torch.bfloat16,
+        attn_implementation="sdpa",  # flash-attn not in env; SDPA is fine for calib
+        trust_remote_code=True,
+    ).to(device)
+    model.model.visual.requires_grad_(False)
+    model.eval()
+
+    captured = {}
+
+    def hook(module, inp, out):
+        captured["hidden"] = out
+
+    h = model.model.language_model.layers[alignment_layer].register_forward_hook(hook)
+    print(f"[calib] hook on layer {alignment_layer}, visual frozen")
+
+    # --- Load N alignment files and remember which row_ids we need ---
+    pt_files = sorted(glob.glob("data/preprocessed/*.pt"))[:num_samples]
+    print(f"[calib] using {len(pt_files)} preprocessed examples")
+    needed = {}
+    for f in pt_files:
+        pt = torch.load(f, weights_only=False)
+        needed[pt["row_id"]] = {
+            "bboxes": pt["bboxes"],
+            "text_reps": pt["text_hidden_states"][:, alignment_layer, :].clone(),
+            "image_size": pt["image_size"],
+            "hash": pt["image_hash"],
+        }
+    max_row = max(needed.keys())
+    print(f"[calib] streaming CoSyn-400K up to row {max_row}...")
+
+    # --- Stream HF dataset and collect matched rows ---
+    dataset = load_dataset(
+        "allenai/CoSyn-400K", "table", split="train", streaming=True
+    )
+    matched = []
+    for stream_idx, sample in enumerate(dataset):
+        if stream_idx > max_row:
+            break
+        if stream_idx not in needed:
+            continue
+        # qa_pairs is a dict-of-lists: {'question': [...], 'answer': [...], ...}
+        qa_pairs = sample.get("qa_pairs", {}) or {}
+        questions = qa_pairs.get("question", []) if isinstance(qa_pairs, dict) else []
+        answers = qa_pairs.get("answer", []) if isinstance(qa_pairs, dict) else []
+        if not questions or not answers:
+            continue
+        img_hash = _image_hash(sample["image"])
+        assert img_hash == needed[stream_idx]["hash"], (
+            f"hash mismatch at row {stream_idx}: "
+            f".pt={needed[stream_idx]['hash']}, stream={img_hash}"
+        )
+        question, answer = questions[0], answers[0]
+        if not question or not answer:
+            continue
+        matched.append({
+            "image": sample["image"],
+            "question": question,
+            "answer": answer,
+            "alignment": needed[stream_idx],
+        })
+    print(f"[calib] matched {len(matched)} usable examples")
+
+    # --- Forward pass on each, compute both losses ---
+    task_losses = []
+    align_losses = []
+
+    for i, item in enumerate(matched):
+        image = item["image"]
+        question = item["question"]
+        answer = item["answer"]
+        align = item["alignment"]
+
+        messages_full = [
+            {"role": "user", "content": [
+                {"type": "image", "image": image},
+                {"type": "text", "text": question},
+            ]},
+            {"role": "assistant", "content": [
+                {"type": "text", "text": answer},
+            ]},
+        ]
+        messages_prompt = [
+            {"role": "user", "content": [
+                {"type": "image", "image": image},
+                {"type": "text", "text": question},
+            ]},
+        ]
+
+        full_text = processor.apply_chat_template(
+            messages_full, tokenize=False, add_generation_prompt=False
+        )
+        prompt_text = processor.apply_chat_template(
+            messages_prompt, tokenize=False, add_generation_prompt=True
+        )
+        image_inputs, _ = process_vision_info(messages_full)
+
+        try:
+            encoded = processor(
+                text=[full_text],
+                images=image_inputs,
+                return_tensors="pt",
+                truncation=True,
+                max_length=max_seq_len,
+            ).to(device)
+            prompt_encoded = processor(
+                text=[prompt_text],
+                images=image_inputs,
+                return_tensors="pt",
+                truncation=True,
+                max_length=max_seq_len,
+            )
+        except ValueError as e:
+            # Image produces more tokens than max_seq_len allows; skip for calib
+            print(f"[calib] {i+1}/{len(matched)}: skipping (oversize image: {e.args[0][:80]}...)")
+            continue
+        prompt_len = prompt_encoded["input_ids"].shape[1]
+
+        labels = encoded["input_ids"].clone()
+        labels[:, :prompt_len] = -100
+
+        with torch.no_grad():
+            outputs = model(
+                input_ids=encoded["input_ids"],
+                attention_mask=encoded["attention_mask"],
+                mm_token_type_ids=encoded["mm_token_type_ids"],
+                pixel_values=encoded["pixel_values"],
+                image_grid_thw=encoded["image_grid_thw"],
+                labels=labels,
+            )
+        task_loss = outputs.loss.item()
+
+        # --- Alignment loss (mean-pool + fp32 MSE; matches compute_alignment_loss) ---
+        layer_hidden = captured["hidden"]
+        orig_w, orig_h = align["image_size"]
+        processed_h, processed_w = get_processed_resolution(
+            encoded["image_grid_thw"], image_index=0
+        )
+        seq_len = layer_hidden.shape[1]
+
+        visual_reps = []
+        text_reps = []
+        for j, bbox in enumerate(align["bboxes"]):
+            scaled = scale_bbox(bbox, orig_w, orig_h, processed_w, processed_h)
+            tok_idxs = find_qwen3vl_image_tokens(
+                encoded["input_ids"][0],
+                encoded["image_grid_thw"],
+                scaled,
+                image_index=0,
+            )
+            valid = [idx for idx in tok_idxs if idx < seq_len]
+            if not valid:
+                continue
+            visual_reps.append(layer_hidden[0, valid, :].mean(dim=0))
+            text_reps.append(align["text_reps"][j])
+
+        captured.clear()
+
+        if not visual_reps:
+            print(f"[calib] {i+1}/{len(matched)}: no valid visual tokens, skipping")
+            continue
+
+        v = torch.stack(visual_reps).float()
+        t = torch.stack(text_reps).to(device).float()
+        align_loss = F.mse_loss(v, t).item()
+
+        task_losses.append(task_loss)
+        align_losses.append(align_loss)
+        print(
+            f"[calib] {i+1}/{len(matched)}: "
+            f"task={task_loss:.4f}  align={align_loss:.4f}  cells={len(visual_reps)}"
+        )
+
+    h.remove()
+
+    if not task_losses:
+        print("[calib] no usable items, nothing to report")
+        return
+
+    task_mean = statistics.mean(task_losses)
+    align_mean = statistics.mean(align_losses)
+    task_std = statistics.stdev(task_losses) if len(task_losses) > 1 else 0.0
+    align_std = statistics.stdev(align_losses) if len(align_losses) > 1 else 0.0
+
+    print("\n=== Calibration Summary ===")
+    print(f"  examples used:    {len(task_losses)}")
+    print(f"  mean task_loss:   {task_mean:.4f}  (std {task_std:.4f})")
+    print(f"  mean align_loss:  {align_mean:.4f}  (std {align_std:.4f})")
+    print(f"  ratio align/task: {align_mean/task_mean:.4f}")
+    w = 0.1 * task_mean / align_mean
+    print(f"  recommended alignment_loss_weight = 0.1 * task / align = {w:.6f}")
+    print(f"    (so w * align_loss ~= 0.1 * task_loss on average)")
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--num-samples", type=int, default=20)
+    p.add_argument("--alignment-layer", type=int, default=16)
+    p.add_argument("--max-seq-len", type=int, default=2048)
+    args = p.parse_args()
+    main(args.num_samples, args.alignment_layer, args.max_seq_len)

--- a/scripts/calibrate_alignment.py
+++ b/scripts/calibrate_alignment.py
@@ -33,9 +33,16 @@ from src.token_map import (
     scale_bbox,
     find_qwen3vl_image_tokens,
 )
+from src.losses import compute_lm_head_bow_loss
 
 
-def main(num_samples: int, alignment_layer: int, max_seq_len: int) -> None:
+def main(
+    num_samples: int,
+    alignment_layer: int,
+    max_seq_len: int,
+    alignment_loss_mode: str,
+    use_final_norm: bool,
+) -> None:
     device = torch.device("cuda")
     model_name = "Qwen/Qwen3-VL-2B-Instruct"
 
@@ -57,6 +64,18 @@ def main(num_samples: int, alignment_layer: int, max_seq_len: int) -> None:
 
     h = model.model.language_model.layers[alignment_layer].register_forward_hook(hook)
     print(f"[calib] hook on layer {alignment_layer}, visual frozen")
+    print(f"[calib] mode={alignment_loss_mode}", end="")
+    if alignment_loss_mode == "lm_head_bow":
+        print(f" (final_norm={'on' if use_final_norm else 'off'})")
+    else:
+        print()
+
+    lm_head_module = model.lm_head if alignment_loss_mode == "lm_head_bow" else None
+    final_norm_module = None
+    if alignment_loss_mode == "lm_head_bow" and use_final_norm:
+        final_norm_module = getattr(model.model.language_model, "norm", None)
+        if final_norm_module is None:
+            print("[calib] WARNING: final_norm requested but model.model.language_model.norm not found")
 
     # --- Load N alignment files and remember which row_ids we need ---
     pt_files = sorted(glob.glob("data/preprocessed/*.pt"))[:num_samples]
@@ -66,6 +85,7 @@ def main(num_samples: int, alignment_layer: int, max_seq_len: int) -> None:
         pt = torch.load(f, weights_only=False)
         needed[pt["row_id"]] = {
             "bboxes": pt["bboxes"],
+            "texts": pt["texts"],
             "text_reps": pt["text_hidden_states"][:, alignment_layer, :].clone(),
             "image_size": pt["image_size"],
             "hash": pt["image_hash"],
@@ -108,6 +128,7 @@ def main(num_samples: int, alignment_layer: int, max_seq_len: int) -> None:
     # --- Forward pass on each, compute both losses ---
     task_losses = []
     align_losses = []
+    all_cell_nlls: list = []  # flattened per-cell NLLs across all examples (lm_head_bow only)
 
     for i, item in enumerate(matched):
         image = item["image"]
@@ -184,6 +205,7 @@ def main(num_samples: int, alignment_layer: int, max_seq_len: int) -> None:
 
         visual_reps = []
         text_reps = []
+        cell_token_ids: list = []
         for j, bbox in enumerate(align["bboxes"]):
             scaled = scale_bbox(bbox, orig_w, orig_h, processed_w, processed_h)
             tok_idxs = find_qwen3vl_image_tokens(
@@ -197,6 +219,11 @@ def main(num_samples: int, alignment_layer: int, max_seq_len: int) -> None:
                 continue
             visual_reps.append(layer_hidden[0, valid, :].mean(dim=0))
             text_reps.append(align["text_reps"][j])
+            if alignment_loss_mode == "lm_head_bow":
+                cell_text = align["texts"][j] if j < len(align["texts"]) else ""
+                cell_token_ids.append(
+                    processor.tokenizer.encode(cell_text or "", add_special_tokens=False)
+                )
 
         captured.clear()
 
@@ -204,15 +231,48 @@ def main(num_samples: int, alignment_layer: int, max_seq_len: int) -> None:
             print(f"[calib] {i+1}/{len(matched)}: no valid visual tokens, skipping")
             continue
 
-        v = torch.stack(visual_reps).float()
-        t = torch.stack(text_reps).to(device).float()
-        align_loss = F.mse_loss(v, t).item()
+        if alignment_loss_mode == "mse":
+            v = torch.stack(visual_reps).float()
+            t = torch.stack(text_reps).to(device).float()
+            align_loss = F.mse_loss(v, t).item()
+            n_cells_used = len(visual_reps)
+        else:  # lm_head_bow
+            v_stack = torch.stack(visual_reps)  # keep in bf16; loss casts to fp32 internally
+            align_loss_t = compute_lm_head_bow_loss(
+                visual_reps=v_stack,
+                cell_token_ids=cell_token_ids,
+                lm_head=lm_head_module,
+                final_norm=final_norm_module,
+            )
+            align_loss = align_loss_t.item()
+            # Per-cell NLL distribution (mirror the math inside compute_lm_head_bow_loss
+            # so we can report quantiles without changing the loss function's API).
+            h_fp = v_stack
+            if final_norm_module is not None:
+                w = final_norm_module.weight.detach()
+                eps = getattr(final_norm_module, "variance_epsilon", getattr(final_norm_module, "eps", 1e-6))
+                in_dtype = h_fp.dtype
+                h_fp = h_fp.float()
+                var = h_fp.pow(2).mean(-1, keepdim=True)
+                h_fp = h_fp * torch.rsqrt(var + eps)
+                h_fp = (h_fp * w.float()).to(in_dtype)
+            W = lm_head_module.weight.detach()
+            b = lm_head_module.bias.detach() if lm_head_module.bias is not None else None
+            logits = F.linear(h_fp, W, b)
+            log_probs = F.log_softmax(logits.float(), dim=-1)
+            for j, ids in enumerate(cell_token_ids):
+                if not ids:
+                    continue
+                ids_t = torch.tensor(ids, device=log_probs.device, dtype=torch.long)
+                nll = -log_probs[j, ids_t].mean().item()
+                all_cell_nlls.append(nll)
+            n_cells_used = sum(1 for ids in cell_token_ids if ids)
 
         task_losses.append(task_loss)
         align_losses.append(align_loss)
         print(
             f"[calib] {i+1}/{len(matched)}: "
-            f"task={task_loss:.4f}  align={align_loss:.4f}  cells={len(visual_reps)}"
+            f"task={task_loss:.4f}  align={align_loss:.4f}  cells={n_cells_used}"
         )
 
     h.remove()
@@ -227,6 +287,8 @@ def main(num_samples: int, alignment_layer: int, max_seq_len: int) -> None:
     align_std = statistics.stdev(align_losses) if len(align_losses) > 1 else 0.0
 
     print("\n=== Calibration Summary ===")
+    print(f"  mode:             {alignment_loss_mode}")
+    print(f"  layer:            {alignment_layer}")
     print(f"  examples used:    {len(task_losses)}")
     print(f"  mean task_loss:   {task_mean:.4f}  (std {task_std:.4f})")
     print(f"  mean align_loss:  {align_mean:.4f}  (std {align_std:.4f})")
@@ -235,11 +297,52 @@ def main(num_samples: int, alignment_layer: int, max_seq_len: int) -> None:
     print(f"  recommended alignment_loss_weight = 0.1 * task / align = {w:.6f}")
     print(f"    (so w * align_loss ~= 0.1 * task_loss on average)")
 
+    if alignment_loss_mode == "lm_head_bow" and all_cell_nlls:
+        nlls = sorted(all_cell_nlls)
+        n = len(nlls)
+        p50 = nlls[n // 2]
+        p95 = nlls[min(n - 1, int(0.95 * n))]
+        nll_mean = statistics.mean(nlls)
+        nll_std = statistics.stdev(nlls) if n > 1 else 0.0
+        print(f"\n=== Per-cell NLL distribution (lm_head_bow) ===")
+        print(f"  cells:            {n}")
+        print(f"  mean:             {nll_mean:.4f}  (std {nll_std:.4f})")
+        print(f"  p50 / p95:        {p50:.4f}  /  {p95:.4f}")
+        print(f"  min / max:        {nlls[0]:.4f}  /  {nlls[-1]:.4f}")
+        print(f"  random-vocab NLL: ~11.93  (log(151643))")
+
 
 if __name__ == "__main__":
     p = argparse.ArgumentParser()
     p.add_argument("--num-samples", type=int, default=20)
     p.add_argument("--alignment-layer", type=int, default=16)
     p.add_argument("--max-seq-len", type=int, default=2048)
+    p.add_argument(
+        "--alignment-loss-mode",
+        type=str,
+        default="mse",
+        choices=["mse", "lm_head_bow"],
+        help="Loss mode to probe. 'mse' (default, original behavior) compares "
+             "visual reps to precomputed text reps. 'lm_head_bow' decodes visual "
+             "reps through the frozen LM head and computes CE against OCR text.",
+    )
+    p.add_argument(
+        "--lm-head-bow-use-final-norm",
+        action="store_true",
+        default=True,
+        help="Apply final RMSNorm (detached) before lm_head in lm_head_bow mode (default: on).",
+    )
+    p.add_argument(
+        "--no-lm-head-bow-use-final-norm",
+        dest="lm_head_bow_use_final_norm",
+        action="store_false",
+        help="Disable the final norm in lm_head_bow mode.",
+    )
     args = p.parse_args()
-    main(args.num_samples, args.alignment_layer, args.max_seq_len)
+    main(
+        args.num_samples,
+        args.alignment_layer,
+        args.max_seq_len,
+        args.alignment_loss_mode,
+        args.lm_head_bow_use_final_norm,
+    )

--- a/scripts/eval_table_metrics.py
+++ b/scripts/eval_table_metrics.py
@@ -1,0 +1,315 @@
+"""
+Evaluate a Qwen3-VL checkpoint (or the base model) on a held-out slice of
+CoSyn-400K. Used for the three-eval ablation:
+    1. Base Qwen3-VL-2B (no training)               — zero-shot
+    2. Task-only fine-tune (alignment_loss_weight=0)
+    3. Task + alignment fine-tune (run1, weight=1e-5)
+
+Reports exact-match (EM) and SQuAD-style token F1.
+
+Held-out slice
+--------------
+The same val_split that train_qwen_cosyn.py uses for val_loss tracking
+(test_size=0.02, seed=42, or raw["validation"] when present). It was never
+trained on. The 200-example subsample is deterministic (subsample_seed=0)
+so all three eval conditions score on identical inputs.
+
+Run on GPU 0
+------------
+    CUDA_VISIBLE_DEVICES=0 python -m scripts.eval_table_metrics \\
+        --checkpoint_path outputs/qwen_cosyn_run1/best_model \\
+        --tag run1 --num_eval_samples 200
+"""
+
+import argparse
+import json
+import os
+import re
+import string
+import time
+from collections import Counter
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+
+from transformers import AutoProcessor, Qwen3VLForConditionalGeneration
+from datasets import load_dataset
+from qwen_vl_utils import process_vision_info
+
+
+# ---------------------------------------------------------------------------
+# Metrics (SQuAD-style)
+# ---------------------------------------------------------------------------
+
+_PUNC_RE = re.compile(f"[{re.escape(string.punctuation)}]")
+
+
+def _normalize(s: str) -> str:
+    """Lowercase, strip articles, drop punctuation, collapse whitespace."""
+    s = s.lower()
+    s = _PUNC_RE.sub(" ", s)
+    s = re.sub(r"\b(a|an|the)\b", " ", s)
+    s = re.sub(r"\s+", " ", s).strip()
+    return s
+
+
+def exact_match(pred: str, gold: str) -> float:
+    return float(_normalize(pred) == _normalize(gold))
+
+
+def token_f1(pred: str, gold: str) -> float:
+    pred_toks = _normalize(pred).split()
+    gold_toks = _normalize(gold).split()
+    if not pred_toks and not gold_toks:
+        return 1.0
+    if not pred_toks or not gold_toks:
+        return 0.0
+    common = Counter(pred_toks) & Counter(gold_toks)
+    num_same = sum(common.values())
+    if num_same == 0:
+        return 0.0
+    precision = num_same / len(pred_toks)
+    recall = num_same / len(gold_toks)
+    return 2 * precision * recall / (precision + recall)
+
+
+# ---------------------------------------------------------------------------
+# Held-out slice (mirrors train_qwen_cosyn.py exactly)
+# ---------------------------------------------------------------------------
+
+def build_eval_items(
+    dataset_name: str,
+    dataset_config: str,
+    val_test_size: float,
+    slice_seed: int,
+    num_eval_samples: int,
+    subsample_seed: int,
+) -> List[Dict]:
+    """
+    Reproduce train_qwen_cosyn.py's val_split logic, then expand to (image,
+    question, answer) items, then deterministically subsample to N items.
+    """
+    raw = load_dataset(dataset_name, dataset_config)
+    if "validation" in raw:
+        val_split = raw["validation"]
+    else:
+        split = raw["train"].train_test_split(
+            test_size=val_test_size, seed=slice_seed
+        )
+        val_split = split["test"]
+
+    items: List[Dict] = []
+    for row_idx, row in enumerate(val_split):
+        qa_pairs = row.get("qa_pairs", {}) or {}
+        questions = qa_pairs.get("question", []) if isinstance(qa_pairs, dict) else []
+        answers = qa_pairs.get("answer", []) if isinstance(qa_pairs, dict) else []
+        if not questions or not answers:
+            continue
+        for qa_idx, (q, a) in enumerate(zip(questions, answers)):
+            if not q or not a:
+                continue
+            items.append({
+                "row_idx": row_idx,
+                "qa_idx": qa_idx,
+                "image": row["image"],
+                "question": q,
+                "answer": a,
+            })
+
+    if num_eval_samples > 0 and num_eval_samples < len(items):
+        rng = np.random.RandomState(subsample_seed)
+        chosen = sorted(rng.choice(len(items), size=num_eval_samples, replace=False).tolist())
+        items = [items[i] for i in chosen]
+
+    return items
+
+
+# ---------------------------------------------------------------------------
+# Generation
+# ---------------------------------------------------------------------------
+
+def generate_answer(
+    model,
+    processor,
+    image,
+    question: str,
+    max_new_tokens: int,
+    max_seq_len: int,
+    device: torch.device,
+) -> str:
+    messages = [{
+        "role": "user",
+        "content": [
+            {"type": "image", "image": image},
+            {"type": "text", "text": question},
+        ],
+    }]
+    prompt_text = processor.apply_chat_template(
+        messages, tokenize=False, add_generation_prompt=True
+    )
+    image_inputs, _ = process_vision_info(messages)
+
+    encoded = processor(
+        text=[prompt_text],
+        images=image_inputs,
+        return_tensors="pt",
+        truncation=True,
+        max_length=max_seq_len,
+    ).to(device)
+
+    prompt_len = encoded["input_ids"].shape[1]
+
+    with torch.no_grad():
+        output_ids = model.generate(
+            **encoded,
+            max_new_tokens=max_new_tokens,
+            do_sample=False,
+            pad_token_id=processor.tokenizer.pad_token_id
+                or processor.tokenizer.eos_token_id,
+        )
+
+    new_tokens = output_ids[0, prompt_len:]
+    text = processor.tokenizer.decode(new_tokens, skip_special_tokens=True)
+    return text.strip()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main(args: argparse.Namespace) -> None:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    # Resolve which weights to load: checkpoint dir if provided, else base.
+    weights_path = args.checkpoint_path or args.model_name
+    print(f"[eval] tag={args.tag}")
+    print(f"[eval] loading processor from base ({args.model_name})")
+    print(f"[eval] loading weights from: {weights_path}")
+
+    processor = AutoProcessor.from_pretrained(args.model_name, trust_remote_code=True)
+    model = Qwen3VLForConditionalGeneration.from_pretrained(
+        weights_path,
+        dtype=torch.bfloat16,
+        attn_implementation=args.attn_implementation,
+        trust_remote_code=True,
+    ).to(device)
+    model.eval()
+
+    print(f"[eval] building eval items from {args.dataset_name}/{args.dataset_config}")
+    items = build_eval_items(
+        dataset_name=args.dataset_name,
+        dataset_config=args.dataset_config,
+        val_test_size=args.val_test_size,
+        slice_seed=args.slice_seed,
+        num_eval_samples=args.num_eval_samples,
+        subsample_seed=args.subsample_seed,
+    )
+    print(f"[eval] running on {len(items)} items")
+
+    predictions: List[Dict] = []
+    em_total = 0.0
+    f1_total = 0.0
+    t0 = time.time()
+
+    for i, item in enumerate(items):
+        try:
+            pred = generate_answer(
+                model=model,
+                processor=processor,
+                image=item["image"],
+                question=item["question"],
+                max_new_tokens=args.max_new_tokens,
+                max_seq_len=args.max_seq_len,
+                device=device,
+            )
+        except Exception as e:
+            print(f"[eval] item {i} generation failed: {e}")
+            pred = ""
+
+        em = exact_match(pred, item["answer"])
+        f1 = token_f1(pred, item["answer"])
+        em_total += em
+        f1_total += f1
+
+        predictions.append({
+            "row_idx": item["row_idx"],
+            "qa_idx": item["qa_idx"],
+            "question": item["question"],
+            "gold": item["answer"],
+            "pred": pred,
+            "em": em,
+            "f1": f1,
+        })
+
+        if (i + 1) % args.log_every == 0 or i == len(items) - 1:
+            elapsed = time.time() - t0
+            rate = (i + 1) / elapsed
+            print(
+                f"[eval] {i + 1}/{len(items)} "
+                f"| EM={em_total / (i + 1):.3f} "
+                f"| F1={f1_total / (i + 1):.3f} "
+                f"| {rate:.2f} it/s"
+            )
+
+    n = len(items)
+    em_score = em_total / n if n else 0.0
+    f1_score = f1_total / n if n else 0.0
+    elapsed = time.time() - t0
+
+    summary = {
+        "tag": args.tag,
+        "checkpoint_path": args.checkpoint_path,
+        "model_name": args.model_name,
+        "dataset_name": args.dataset_name,
+        "dataset_config": args.dataset_config,
+        "num_items": n,
+        "slice_seed": args.slice_seed,
+        "val_test_size": args.val_test_size,
+        "subsample_seed": args.subsample_seed,
+        "exact_match": em_score,
+        "token_f1": f1_score,
+        "elapsed_sec": elapsed,
+    }
+
+    os.makedirs(os.path.dirname(args.output_path) or ".", exist_ok=True)
+    with open(args.output_path, "w") as f:
+        json.dump(summary, f, indent=2)
+    pred_path = args.output_path.replace(".json", "_predictions.jsonl")
+    with open(pred_path, "w") as f:
+        for p in predictions:
+            f.write(json.dumps(p) + "\n")
+
+    print(f"[eval] DONE — EM={em_score:.4f} F1={f1_score:.4f} on {n} items "
+          f"in {elapsed:.1f}s")
+    print(f"[eval] summary  → {args.output_path}")
+    print(f"[eval] preds    → {pred_path}")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--checkpoint_path", type=str, default=None,
+                   help="Path to fine-tuned checkpoint dir. None = use base model.")
+    p.add_argument("--model_name", type=str, default="Qwen/Qwen3-VL-2B-Instruct")
+    p.add_argument("--dataset_name", type=str, default="allenai/CoSyn-400K")
+    p.add_argument("--dataset_config", type=str, default="table")
+    p.add_argument("--max_seq_len", type=int, default=4096)
+    p.add_argument("--max_new_tokens", type=int, default=256)
+    p.add_argument("--num_eval_samples", type=int, default=200,
+                   help="0 = use full val_split. Default 200 for tractability.")
+    p.add_argument("--slice_seed", type=int, default=42,
+                   help="Must match train_qwen_cosyn val_split seed.")
+    p.add_argument("--val_test_size", type=float, default=0.02,
+                   help="Must match train_qwen_cosyn val_test_size.")
+    p.add_argument("--subsample_seed", type=int, default=0)
+    p.add_argument("--attn_implementation", type=str, default="sdpa")
+    p.add_argument("--log_every", type=int, default=10)
+    p.add_argument("--output_path", type=str, required=True,
+                   help="Where to save the summary JSON.")
+    p.add_argument("--tag", type=str, required=True,
+                   help="Label for this eval (e.g., 'base', 'task_only', 'run1').")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/scripts/launch_align.sh
+++ b/scripts/launch_align.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Launch wrapper for src.train_qwen_cosyn that survives the failure mode
+# from run3 (silent death with block-buffered stdout).
+#
+# Inputs (env vars, all required unless defaulted):
+#   GPU             - CUDA_VISIBLE_DEVICES (default: 0)
+#   OUT_DIR         - --output_dir (required)
+#   LOG             - log file path (required)
+#   ALIGN_W         - --alignment_loss_weight (required)
+#   ALIGN_LAYER     - --alignment_layer (required)
+#   ALIGN_MODE      - --alignment_loss_mode (default: lm_head_bow)
+#   FINAL_NORM      - "on" or "off" for --lm_head_bow_use_final_norm (default: on)
+#   EPOCHS          - --num_epochs (default: 1)
+#   PER_BS          - --per_device_batch_size (default: 2)
+#   ACCUM           - --grad_accum_steps (default: 8)
+#   SAVE_STEPS      - --save_steps (default: 2000)
+#   SAVE_LIMIT      - --save_total_limit (default: 2)
+#   LOG_EVERY       - --log_every (default: 50)
+#   ATTN            - --attn_implementation (default: sdpa)
+#   N_TRAIN         - --num_train_samples (default: 0 = full)
+#   N_VAL           - --num_val_samples (default: 0 = full)
+#   RESUME_FROM     - --resume_from path (default: empty)
+#
+# Behavior:
+#   - Sets PYTHONUNBUFFERED=1 and runs python -u so stdout is unbuffered.
+#   - Pipes through tee so stderr survives if the python process dies suddenly.
+#   - Detaches via nohup + disown so SSH disconnects don't kill it.
+#   - Writes the PID to ${OUT_DIR}/run.pid for the watchdog.
+
+set -euo pipefail
+
+: "${OUT_DIR:?OUT_DIR is required}"
+: "${LOG:?LOG is required}"
+: "${ALIGN_W:?ALIGN_W is required}"
+: "${ALIGN_LAYER:?ALIGN_LAYER is required}"
+
+GPU="${GPU:-0}"
+ALIGN_MODE="${ALIGN_MODE:-lm_head_bow}"
+FINAL_NORM="${FINAL_NORM:-on}"
+EPOCHS="${EPOCHS:-1}"
+PER_BS="${PER_BS:-2}"
+ACCUM="${ACCUM:-8}"
+SAVE_STEPS="${SAVE_STEPS:-2000}"
+SAVE_LIMIT="${SAVE_LIMIT:-2}"
+LOG_EVERY="${LOG_EVERY:-50}"
+ATTN="${ATTN:-sdpa}"
+N_TRAIN="${N_TRAIN:-0}"
+N_VAL="${N_VAL:-0}"
+RESUME_FROM="${RESUME_FROM:-}"
+
+REPO_ROOT="/data2/hshah057/rushi_workspace/SeniorResearchProject"
+PYBIN="/data2/hshah057/miniconda/envs/rushi_vlm/bin/python"
+
+mkdir -p "$(dirname "$LOG")" "$OUT_DIR"
+
+FINAL_NORM_FLAG="--lm_head_bow_use_final_norm"
+if [[ "$FINAL_NORM" == "off" ]]; then
+  FINAL_NORM_FLAG="--no-lm_head_bow_use_final_norm"
+fi
+
+RESUME_FLAG=""
+if [[ -n "$RESUME_FROM" ]]; then
+  RESUME_FLAG="--resume_from $RESUME_FROM"
+fi
+
+ALIGNED_FLAG=""
+if [[ "${ALIGNED_ONLY:-off}" == "on" ]]; then
+  ALIGNED_FLAG="--aligned_only"
+fi
+
+cd "$REPO_ROOT"
+
+# Stamp the launch in the log header so it's easy to grep
+{
+  echo "=== launch_align.sh at $(date -Iseconds) ==="
+  echo "GPU=$GPU OUT_DIR=$OUT_DIR ALIGN_W=$ALIGN_W ALIGN_LAYER=$ALIGN_LAYER ALIGN_MODE=$ALIGN_MODE FINAL_NORM=$FINAL_NORM"
+  echo "EPOCHS=$EPOCHS PER_BS=$PER_BS ACCUM=$ACCUM SAVE_STEPS=$SAVE_STEPS SAVE_LIMIT=$SAVE_LIMIT LOG_EVERY=$LOG_EVERY ATTN=$ATTN N_TRAIN=$N_TRAIN N_VAL=$N_VAL"
+  if [[ -n "$RESUME_FROM" ]]; then echo "RESUME_FROM=$RESUME_FROM"; fi
+} >> "$LOG"
+
+# shellcheck disable=SC2086
+nohup env \
+  PYTHONNOUSERSITE=1 \
+  PYTHONUNBUFFERED=1 \
+  CUDA_VISIBLE_DEVICES="$GPU" \
+  HF_HOME=/data2/hshah057/rushi_workspace/hf_cache \
+  PYTHONPATH=. \
+  "$PYBIN" -u -m src.train_qwen_cosyn \
+    --alignment_loss_mode "$ALIGN_MODE" \
+    $FINAL_NORM_FLAG \
+    --alignment_loss_weight "$ALIGN_W" \
+    --alignment_layer "$ALIGN_LAYER" \
+    --num_epochs "$EPOCHS" \
+    --per_device_batch_size "$PER_BS" \
+    --grad_accum_steps "$ACCUM" \
+    --save_steps "$SAVE_STEPS" \
+    --save_total_limit "$SAVE_LIMIT" \
+    --log_every "$LOG_EVERY" \
+    --attn_implementation "$ATTN" \
+    --num_train_samples "$N_TRAIN" \
+    --num_val_samples "$N_VAL" \
+    --output_dir "$OUT_DIR" \
+    $RESUME_FLAG \
+    $ALIGNED_FLAG \
+  >> "$LOG" 2>&1 &
+
+PID=$!
+echo "$PID" > "$OUT_DIR/run.pid"
+disown $PID 2>/dev/null || true
+
+echo "[launch_align.sh] started PID=$PID"
+echo "[launch_align.sh] log=$LOG"
+echo "[launch_align.sh] pid_file=$OUT_DIR/run.pid"

--- a/scripts/watchdog.sh
+++ b/scripts/watchdog.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Generic watchdog. Replaces run3-specific watchdog_run3.sh.
+#
+# Inputs (env vars):
+#   WD_PID       - PID to monitor (required)
+#   WD_LOG       - log file path to inspect on death and stall (required)
+#   WD_LABEL     - label for the alert file (default: job)
+#   WD_STALL_SEC - warn (don't kill) if log mtime exceeds this many seconds (default: 600)
+#   WD_POLL_SEC  - poll interval (default: 60)
+#   WD_ALERT_DIR - dir to write alerts to (default: dirname of WD_LOG)
+#
+# Behavior:
+#   - Polls `kill -0 $WD_PID` every WD_POLL_SEC seconds.
+#   - On PID death: writes alert with last 100 lines of WD_LOG; exits.
+#   - If log mtime exceeds WD_STALL_SEC and process is still alive, prints
+#     a STALL warning to stdout. Does NOT kill (could be a long validation pass).
+#   - Does NOT auto-restart (would just re-trigger whatever killed it).
+
+set -euo pipefail
+
+: "${WD_PID:?WD_PID is required}"
+: "${WD_LOG:?WD_LOG is required}"
+
+WD_LABEL="${WD_LABEL:-job}"
+WD_STALL_SEC="${WD_STALL_SEC:-600}"
+WD_POLL_SEC="${WD_POLL_SEC:-60}"
+WD_ALERT_DIR="${WD_ALERT_DIR:-$(dirname "$WD_LOG")}"
+
+mkdir -p "$WD_ALERT_DIR"
+
+echo "[watchdog] $(date -Iseconds) starting: PID=$WD_PID log=$WD_LOG label=$WD_LABEL stall=${WD_STALL_SEC}s poll=${WD_POLL_SEC}s"
+
+last_stall_warn_t=0
+
+while true; do
+  if ! kill -0 "$WD_PID" 2>/dev/null; then
+    ALERT="$WD_ALERT_DIR/watchdog_alert_${WD_LABEL}_$(date +%s).txt"
+    {
+      echo "=== watchdog alert ==="
+      echo "PID:    $WD_PID"
+      echo "LABEL:  $WD_LABEL"
+      echo "LOG:    $WD_LOG"
+      echo "TIME:   $(date -Iseconds)"
+      echo ""
+      echo "=== last 100 log lines ==="
+      if [[ -f "$WD_LOG" ]]; then
+        tail -n 100 "$WD_LOG"
+      else
+        echo "(log file missing)"
+      fi
+    } > "$ALERT"
+    echo "[watchdog] $(date -Iseconds) PID $WD_PID exited; alert written to $ALERT"
+    exit 0
+  fi
+
+  # Stall check
+  if [[ -f "$WD_LOG" ]]; then
+    now_t=$(date +%s)
+    log_mtime=$(stat -c %Y "$WD_LOG")
+    age=$(( now_t - log_mtime ))
+    if (( age > WD_STALL_SEC )); then
+      # warn at most once every WD_STALL_SEC to avoid log spam
+      if (( now_t - last_stall_warn_t > WD_STALL_SEC )); then
+        echo "[watchdog] $(date -Iseconds) STALL: log idle for ${age}s (threshold ${WD_STALL_SEC}s); PID $WD_PID still alive"
+        last_stall_warn_t=$now_t
+      fi
+    fi
+  fi
+
+  sleep "$WD_POLL_SEC"
+done

--- a/src/losses.py
+++ b/src/losses.py
@@ -1,16 +1,20 @@
 """
 Alignment loss functions.
 
-Two loss modes:
+Loss modes:
   - "cosine":       simple mean of (1 - cosine_similarity) for matched pairs
   - "contrastive":  symmetric InfoNCE / CLIP-style contrastive loss
+  - "lm_head_bow":  CE between LM-head logits of pooled visual reps and the
+                    bag of OCR cell tokens (frozen lm_head used as a probe).
 
 Lower loss = better alignment between matched image-text pairs.
 """
 
+from typing import List, Literal, Optional
+
 import torch
+import torch.nn as nn
 import torch.nn.functional as F
-from typing import Literal
 
 
 def compute_alignment_loss(
@@ -84,6 +88,83 @@ def compute_alignment_loss(
 
     else:
         raise ValueError(f"Unknown loss mode: '{mode}'. Use 'cosine' or 'contrastive'.")
+
+    return loss
+
+
+def compute_lm_head_bow_loss(
+    visual_reps: torch.Tensor,
+    cell_token_ids: List[List[int]],
+    lm_head: nn.Linear,
+    final_norm: Optional[nn.Module] = None,
+    verbose: bool = False,
+) -> torch.Tensor:
+    """
+    Decode pooled visual reps through a frozen LM head and compute bag-of-words
+    cross-entropy against OCR cell tokens.
+
+    Per Sameen (2026-05-13), inspired by the "VLM needs words" finding:
+    intermediate-layer visual reps are partially decodable through the LM head,
+    so push them to be linguistically decodable against ground-truth OCR.
+
+    lm_head weights are detached so gradients flow into the visual reps (and
+    thus into the LM layers that produced them) but NOT into lm_head itself —
+    the head stays a fixed probe; the visual stream has to move to match it.
+
+    Args:
+        visual_reps:     [num_cells, hidden_dim] pooled visual reps in fp32 or bf16.
+        cell_token_ids:  per-cell list of token IDs (no special tokens).
+                         Length must equal num_cells. Empty cells are skipped.
+        lm_head:         model.lm_head (or equivalent Linear projecting hidden → vocab).
+        final_norm:      optional final LM norm (e.g. RMSNorm) applied with detached
+                         params before lm_head. None = skip the norm.
+        verbose:         print per-cell NLLs.
+
+    Returns:
+        Scalar loss (mean over non-empty cells). Returns 0.0 if all cells are empty.
+    """
+    assert visual_reps.dim() == 2, f"Expected 2D visual_reps, got {visual_reps.shape}"
+    assert len(cell_token_ids) == visual_reps.shape[0], (
+        f"cell_token_ids length {len(cell_token_ids)} != num_cells {visual_reps.shape[0]}"
+    )
+
+    # Apply final norm with detached params (if provided) — same dtype as visual_reps
+    h = visual_reps
+    if final_norm is not None:
+        # RMSNorm/LayerNorm has a `weight` param; detach to freeze.
+        # Cleanest way: a functional re-apply using detached params.
+        weight = final_norm.weight.detach()
+        eps = getattr(final_norm, "variance_epsilon", getattr(final_norm, "eps", 1e-6))
+        # RMSNorm: x * rsqrt(mean(x^2) + eps) * weight
+        in_dtype = h.dtype
+        h = h.float()
+        variance = h.pow(2).mean(-1, keepdim=True)
+        h = h * torch.rsqrt(variance + eps)
+        h = (h * weight.float()).to(in_dtype)
+
+    # Logits via detached lm_head (functional form so weights stay frozen for this loss)
+    W = lm_head.weight.detach()
+    b = lm_head.bias.detach() if lm_head.bias is not None else None
+    logits = F.linear(h, W, b)  # [num_cells, vocab]
+
+    log_probs = F.log_softmax(logits.float(), dim=-1)
+
+    cell_nlls = []
+    for j, token_ids in enumerate(cell_token_ids):
+        if not token_ids:
+            continue
+        ids = torch.tensor(token_ids, device=log_probs.device, dtype=torch.long)
+        # Bag-of-words NLL: average -log p(token) across the cell's tokens
+        nll = -log_probs[j, ids].mean()
+        cell_nlls.append(nll)
+
+    if not cell_nlls:
+        return torch.tensor(0.0, device=visual_reps.device, requires_grad=False)
+
+    loss = torch.stack(cell_nlls).mean()
+
+    if verbose:
+        print(f"[losses] LM-head BoW loss: {loss.item():.4f} over {len(cell_nlls)} cells")
 
     return loss
 

--- a/src/ocr_to_tokens.py
+++ b/src/ocr_to_tokens.py
@@ -7,8 +7,11 @@ to measure how many visual tokens each table cell maps to.
 
 import argparse
 import json
+import math
 from pathlib import Path
+from typing import Optional
 
+from PIL import Image
 from transformers import AutoProcessor
 
 from src.ocr_utils import bb_and_text_from_table_image
@@ -20,7 +23,7 @@ def main(image_path: str, model_name: str = "Qwen/Qwen3-VL-2B-Instruct") -> None
 
     # --- Step 1: OCR ---
     print(f"\n[pipeline] Running OCR on: {image_path}")
-    bbs, texts = bb_and_text_from_table_image(image_path)
+    bbs, texts = bb_and_text_from_table_image(image_path=image_path)
     print(f"[pipeline] OCR found {len(bbs)} cells.\n")
 
     # --- Step 2: Load processor (model not needed for token index mapping) ---
@@ -50,6 +53,120 @@ def main(image_path: str, model_name: str = "Qwen/Qwen3-VL-2B-Instruct") -> None
     print(f"[pipeline] Results saved to {output_path}")
 
 
+def validate_cosyn(
+    num_samples: int = 20,
+    model_name: str = "Qwen/Qwen3-VL-2B-Instruct",
+    gpu_ocr: bool = False,
+) -> None:
+    """
+    Validate the OCR → token-index pipeline on real CoSyn-400K table images.
+
+    Loads num_samples images from allenai/CoSyn-400K (table config), runs OCR
+    and token mapping on each, and reports aggregate tokens-per-cell statistics.
+    """
+    from datasets import load_dataset
+
+    print(f"\n[validate] Loading CoSyn-400K (table config) via streaming...")
+    dataset = load_dataset("allenai/CoSyn-400K", "table", split="train", streaming=True)
+
+    # Take first num_samples via streaming (no full download needed)
+    samples = list(dataset.take(num_samples))
+    print(f"[validate] Loaded {len(samples)} samples")
+
+    print(f"[validate] Loading Qwen3-VL processor from '{model_name}'...")
+    processor = AutoProcessor.from_pretrained(model_name)
+    print("[validate] Processor ready.\n")
+
+    all_counts = []
+    total_cells = 0
+    skipped = 0
+
+    total_samples = len(samples)
+    for i, sample in enumerate(samples):
+        pil_image: Image.Image = sample["image"]
+        print(f"\n[validate] === Image {i+1}/{total_samples} ({pil_image.size}) ===")
+
+        # --- OCR ---
+        bbs, texts = bb_and_text_from_table_image(
+            pil_image=pil_image,
+            gpu=gpu_ocr,
+            visualize=False,
+        )
+
+        if len(bbs) == 0:
+            print(f"[validate] No OCR detections — skipping")
+            skipped += 1
+            continue
+
+        # --- Token mapping ---
+        token_indices_list = bb_to_token_indices(
+            pil_image=pil_image,
+            bbs=bbs,
+            processor=processor,
+        )
+
+        # --- Validate indices ---
+        # Total vision tokens = h_patches * w_patches from processor output
+        # We verify indices are non-negative (basic sanity check)
+        for j, indices in enumerate(token_indices_list):
+            if any(idx < 0 for idx in indices):
+                print(f"[validate] WARNING: Negative index in cell {j}")
+
+        # --- Collect stats ---
+        counts = [len(idxs) for idxs in token_indices_list]
+        all_counts.extend(counts)
+        total_cells += len(bbs)
+
+        stats = compute_token_stats(bbs, texts, token_indices_list)
+
+    # --- Aggregate report ---
+    print("\n" + "=" * 70)
+    print("[validate] AGGREGATE RESULTS")
+    print("=" * 70)
+    print(f"  Images processed: {total_samples - skipped}")
+    print(f"  Images skipped (no OCR): {skipped}")
+    print(f"  Total cells: {total_cells}")
+
+    if all_counts:
+        mean_val = sum(all_counts) / len(all_counts)
+        sorted_counts = sorted(all_counts)
+        n = len(sorted_counts)
+        median_val = (
+            sorted_counts[n // 2]
+            if n % 2 == 1
+            else (sorted_counts[n // 2 - 1] + sorted_counts[n // 2]) / 2
+        )
+        min_val = min(all_counts)
+        max_val = max(all_counts)
+        variance = sum((c - mean_val) ** 2 for c in all_counts) / n
+        std_val = math.sqrt(variance)
+
+        print(f"  Mean tokens/cell: {mean_val:.2f}")
+        print(f"  Median:           {median_val}")
+        print(f"  Min / Max:        {min_val} / {max_val}")
+        print(f"  Std dev:          {std_val:.2f}")
+
+        # Save aggregate results
+        output_path = Path("outputs") / "cosyn_validation_stats.json"
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "w") as f:
+            json.dump({
+                "images_processed": total_samples - skipped,
+                "images_skipped": skipped,
+                "total_cells": total_cells,
+                "mean_tokens": mean_val,
+                "median_tokens": median_val,
+                "min_tokens": min_val,
+                "max_tokens": max_val,
+                "std_tokens": std_val,
+            }, f, indent=2)
+        print(f"\n[validate] Results saved to {output_path}")
+    else:
+        print("  No cells detected across any images!")
+
+    print("=" * 70)
+
+
 if __name__ == "__main__":
     from src.synthetic_data import generate_sample_table_image  # local import
 
@@ -68,7 +185,30 @@ if __name__ == "__main__":
         default="Qwen/Qwen3-VL-2B-Instruct",
         help="HuggingFace model identifier for Qwen3-VL.",
     )
+    parser.add_argument(
+        "--validate-cosyn",
+        action="store_true",
+        help="Run validation on CoSyn-400K images instead of a single image.",
+    )
+    parser.add_argument(
+        "--num-samples",
+        type=int,
+        default=20,
+        help="Number of CoSyn-400K images to validate on (default: 20).",
+    )
+    parser.add_argument(
+        "--gpu-ocr",
+        action="store_true",
+        help="Use GPU for EasyOCR.",
+    )
     args = parser.parse_args()
 
-    resolved_path = args.image_path or generate_sample_table_image()
-    main(image_path=resolved_path, model_name=args.model_name)
+    if args.validate_cosyn:
+        validate_cosyn(
+            num_samples=args.num_samples,
+            model_name=args.model_name,
+            gpu_ocr=args.gpu_ocr,
+        )
+    else:
+        resolved_path = args.image_path or generate_sample_table_image()
+        main(image_path=resolved_path, model_name=args.model_name)

--- a/src/ocr_utils.py
+++ b/src/ocr_utils.py
@@ -28,7 +28,8 @@ def _get_reader(gpu: bool = False) -> easyocr.Reader:
 
 
 def bb_and_text_from_table_image(
-    image_path: str,
+    image_path: Optional[str] = None,
+    pil_image: Optional[Image.Image] = None,
     gpu: bool = False,
     min_confidence: float = 0.20,
     visualize: bool = True,
@@ -38,7 +39,8 @@ def bb_and_text_from_table_image(
     Detect text regions in a table image and extract bounding boxes + OCR text.
 
     Args:
-        image_path:      Path to the input image.
+        image_path:      Path to the input image (provide this OR pil_image).
+        pil_image:       PIL Image object (alternative to image_path).
         gpu:             Whether to use GPU for OCR.
         min_confidence:  Minimum OCR confidence to keep a detection.
         visualize:       If True, save an annotated image with boxes drawn.
@@ -49,19 +51,23 @@ def bb_and_text_from_table_image(
         texts: List of OCR-extracted strings (same length as bbs).
     """
     # --- Load image ---
-    if not Path(image_path).exists():
-        raise FileNotFoundError(f"Image not found: {image_path}")
-
-    img_cv = cv2.imread(image_path)
-    if img_cv is None:
-        raise ValueError(f"Could not read image at {image_path}")
+    if pil_image is not None:
+        img_cv = cv2.cvtColor(np.array(pil_image.convert("RGB")), cv2.COLOR_RGB2BGR)
+    elif image_path is not None:
+        if not Path(image_path).exists():
+            raise FileNotFoundError(f"Image not found: {image_path}")
+        img_cv = cv2.imread(image_path)
+        if img_cv is None:
+            raise ValueError(f"Could not read image at {image_path}")
+    else:
+        raise ValueError("Must provide either image_path or pil_image")
 
     reader = _get_reader(gpu=gpu)
 
     # --- Run OCR ---
     # EasyOCR returns list of (bbox_polygon, text, confidence)
     # bbox_polygon is [[x1,y1],[x2,y2],[x3,y3],[x4,y4]] (quadrilateral)
-    raw_results = reader.readtext(image_path)
+    raw_results = reader.readtext(img_cv)
     print(f"[ocr_utils] Raw OCR detections: {len(raw_results)}")
 
     bbs: List[Tuple[int, int, int, int]] = []
@@ -99,7 +105,7 @@ def bb_and_text_from_table_image(
         print(f"  [{i}] box={bb}  text='{txt}'")
 
     # --- Visualization ---
-    if visualize:
+    if visualize and image_path is not None:
         _visualize_detections(image_path, bbs, texts, output_dir)
 
     return bbs, texts
@@ -148,5 +154,5 @@ if __name__ == "__main__":
     from src.synthetic_data import generate_sample_table_image
 
     path = sys.argv[1] if len(sys.argv) > 1 else generate_sample_table_image()
-    bbs, texts = bb_and_text_from_table_image(path)
+    bbs, texts = bb_and_text_from_table_image(image_path=path)
     print(f"\nTotal detections: {len(bbs)}")

--- a/src/preprocess_cosyn.py
+++ b/src/preprocess_cosyn.py
@@ -1,0 +1,274 @@
+"""
+preprocess_cosyn.py
+
+Preprocess a subset of CoSyn-400K for alignment loss training:
+  1. Subsample N examples (deterministic via Python random, seed=42)
+  2. Run EasyOCR on each image → (bboxes, texts)
+  3. Pass each text through Qwen3-VL's LM (text-only, no image)
+  4. Extract hidden states from all layers, mean-pool over tokens
+  5. Save per-example .pt files
+
+One-time run. If interrupted, delete output dir and restart.
+"""
+
+import argparse
+import hashlib
+import json
+import random
+from pathlib import Path
+from typing import List, Tuple
+
+import torch
+from PIL import Image
+from tqdm import tqdm
+from transformers import AutoProcessor, AutoModelForCausalLM
+
+from src.ocr_utils import bb_and_text_from_table_image
+
+
+def get_image_hash(pil_image: Image.Image) -> str:
+    """Compute a short SHA256 hash of image bytes for data integrity."""
+    return hashlib.sha256(pil_image.tobytes()).hexdigest()[:16]
+
+
+def extract_text_hidden_states(
+    texts: List[str],
+    processor: AutoProcessor,
+    model: torch.nn.Module,
+    device: torch.device,
+    batch_size: int = 64,
+) -> torch.Tensor:
+    """
+    Run text-only forward passes through Qwen3-VL's LM and extract
+    mean-pooled hidden states from all layers.
+
+    Args:
+        texts: List of OCR text strings.
+        processor: Qwen3-VL processor (used for tokenization).
+        model: Qwen3-VL model (full model, we use the language_model part).
+        device: Torch device.
+        batch_size: Texts per forward pass.
+
+    Returns:
+        Tensor of shape [num_texts, num_layers, hidden_dim] in bf16.
+    """
+    all_hidden_states = []
+
+    for i in range(0, len(texts), batch_size):
+        batch_texts = texts[i : i + batch_size]
+
+        # Tokenize text-only (no image)
+        inputs = processor.tokenizer(
+            batch_texts,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=128,
+        ).to(device)
+
+        with torch.no_grad():
+            outputs = model(
+                input_ids=inputs["input_ids"],
+                attention_mask=inputs["attention_mask"],
+                output_hidden_states=True,
+            )
+
+        # outputs.hidden_states is a tuple of (num_layers + 1) tensors
+        # Each tensor: [batch, seq_len, hidden_dim]
+        # Skip index 0 (embedding layer), keep layers 1..N
+        hidden_states = outputs.hidden_states[1:]  # 28 layers for 2B model
+        num_layers = len(hidden_states)
+
+        # Mean-pool over non-padding tokens for each text in the batch
+        attention_mask = inputs["attention_mask"]  # [batch, seq_len]
+        mask_expanded = attention_mask.unsqueeze(-1)  # [batch, seq_len, 1]
+
+        for j in range(len(batch_texts)):
+            # Stack all layers for this text: [num_layers, seq_len, hidden_dim]
+            text_layers = torch.stack(
+                [hidden_states[layer][j] for layer in range(num_layers)]
+            )
+            # Expand mask for this text: [1, seq_len, 1]
+            text_mask = mask_expanded[j].unsqueeze(0)  # [1, seq_len, 1]
+            # Mean-pool: [num_layers, hidden_dim]
+            pooled = (text_layers * text_mask).sum(dim=1) / text_mask.sum(dim=1).clamp(min=1)
+            all_hidden_states.append(pooled)
+
+    # Stack all texts: [num_texts, num_layers, hidden_dim]
+    return torch.stack(all_hidden_states)
+
+
+def preprocess(
+    num_samples: int = 5000,
+    model_name: str = "Qwen/Qwen3-VL-2B-Instruct",
+    output_dir: str = "data/preprocessed",
+    seed: int = 42,
+    gpu_ocr: bool = False,
+    batch_size: int = 64,
+) -> None:
+    """
+    Preprocess CoSyn-400K subset: OCR + text hidden state extraction.
+
+    Processor resolution contract: uses AutoProcessor.from_pretrained(model_name)
+    with default settings. Training must use the same processor defaults.
+    """
+    from datasets import load_dataset
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # --- Load dataset via streaming (avoids full download) ---
+    print(f"[preprocess] Loading CoSyn-400K (table config) via streaming...")
+    dataset = load_dataset("allenai/CoSyn-400K", "table", split="train", streaming=True)
+
+    # --- Deterministic subsampling with Python random ---
+    # We stream and collect, skipping zero-detection examples
+    print(f"[preprocess] Collecting {num_samples} samples (seed={seed})...")
+    # Note: with streaming we can't shuffle by index, so we take a larger
+    # pool and subsample from it. For the full 5K run, we take sequentially
+    # and rely on the dataset's natural ordering.
+    # For reproducibility, we process in order and skip zero-detection images.
+
+    # --- Load model + processor ---
+    print(f"[preprocess] Loading Qwen3-VL model from '{model_name}'...")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    processor = AutoProcessor.from_pretrained(model_name)
+
+    # Load only the language model part for text-only forward passes
+    # We load the full model but only use it for text encoding
+    from transformers import Qwen3VLForConditionalGeneration
+    model = Qwen3VLForConditionalGeneration.from_pretrained(
+        model_name,
+        torch_dtype=torch.bfloat16,
+    ).to(device)
+    model.eval()
+
+    # Record processor config for resolution contract enforcement
+    processor_config = {
+        "model_name": model_name,
+        "min_pixels": getattr(processor.image_processor, "min_pixels", None),
+        "max_pixels": getattr(processor.image_processor, "max_pixels", None),
+    }
+    print(f"[preprocess] Processor config: {processor_config}")
+    print(f"[preprocess] Device: {device}")
+
+    # --- Process images ---
+    saved = 0
+    skipped = 0
+    skipped_indices = []
+
+    pbar = tqdm(total=num_samples, desc="Preprocessing")
+
+    for stream_idx, sample in enumerate(dataset):
+        if saved >= num_samples:
+            break
+
+        pil_image: Image.Image = sample["image"]
+
+        # --- OCR ---
+        bbs, texts = bb_and_text_from_table_image(
+            pil_image=pil_image,
+            gpu=gpu_ocr,
+            visualize=False,
+        )
+
+        if len(bbs) == 0:
+            skipped += 1
+            skipped_indices.append(stream_idx)
+            continue
+
+        # --- Extract text hidden states ---
+        text_hidden_states = extract_text_hidden_states(
+            texts=texts,
+            processor=processor,
+            model=model,
+            device=device,
+            batch_size=batch_size,
+        )
+        # text_hidden_states shape: [num_cells, num_layers, hidden_dim]
+
+        # --- Compute image hash for data integrity ---
+        image_hash = get_image_hash(pil_image)
+
+        # --- Save .pt file ---
+        pt_data = {
+            "idx": saved,
+            "row_id": stream_idx,
+            "bboxes": bbs,
+            "texts": texts,
+            "text_hidden_states": text_hidden_states.cpu(),
+            "image_size": pil_image.size,  # (width, height)
+            "processor_config": processor_config,
+            "image_hash": image_hash,
+        }
+
+        pt_path = output_path / f"{saved:05d}.pt"
+        torch.save(pt_data, pt_path)
+
+        saved += 1
+        pbar.update(1)
+        pbar.set_postfix(skipped=skipped, cells=len(bbs))
+
+    pbar.close()
+
+    # --- Summary ---
+    print(f"\n[preprocess] Done!")
+    print(f"  Saved: {saved} examples")
+    print(f"  Skipped (no OCR): {skipped}")
+    print(f"  Output dir: {output_path}")
+    if skipped_indices:
+        print(f"  Skipped stream indices: {skipped_indices[:20]}{'...' if len(skipped_indices) > 20 else ''}")
+
+    # Save metadata
+    metadata = {
+        "num_samples": saved,
+        "skipped": skipped,
+        "seed": seed,
+        "model_name": model_name,
+        "processor_config": processor_config,
+        "skipped_indices": skipped_indices,
+    }
+    with open(output_path / "metadata.json", "w") as f:
+        json.dump(metadata, f, indent=2)
+    print(f"  Metadata saved to {output_path / 'metadata.json'}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Preprocess CoSyn-400K for alignment loss training"
+    )
+    parser.add_argument(
+        "--num-samples", type=int, default=5000,
+        help="Number of examples to preprocess (default: 5000)",
+    )
+    parser.add_argument(
+        "--model-name", type=str, default="Qwen/Qwen3-VL-2B-Instruct",
+        help="HuggingFace model identifier for Qwen3-VL",
+    )
+    parser.add_argument(
+        "--output-dir", type=str, default="data/preprocessed",
+        help="Output directory for .pt files",
+    )
+    parser.add_argument(
+        "--seed", type=int, default=42,
+        help="Random seed for subsampling",
+    )
+    parser.add_argument(
+        "--gpu-ocr", action="store_true",
+        help="Use GPU for EasyOCR",
+    )
+    parser.add_argument(
+        "--batch-size", type=int, default=64,
+        help="Batch size for text-only forward passes",
+    )
+    args = parser.parse_args()
+
+    preprocess(
+        num_samples=args.num_samples,
+        model_name=args.model_name,
+        output_dir=args.output_dir,
+        seed=args.seed,
+        gpu_ocr=args.gpu_ocr,
+        batch_size=args.batch_size,
+    )

--- a/src/token_map.py
+++ b/src/token_map.py
@@ -14,7 +14,7 @@ from typing import List, Tuple, Optional, Dict, Any
 
 import torch
 from PIL import Image
-from transformers import AutoProcessor, Qwen2_5_VLForConditionalGeneration
+from transformers import AutoProcessor, Qwen3VLForConditionalGeneration
 
 
 # ---------------------------------------------------------------------------
@@ -30,18 +30,17 @@ VISION_END_ID: int = 151653
 # ---------------------------------------------------------------------------
 # Module-level model / processor cache — load once, reuse everywhere
 # ---------------------------------------------------------------------------
-_model: Optional[Qwen2_5_VLForConditionalGeneration] = None
+_model: Optional[Qwen3VLForConditionalGeneration] = None
 _processor: Optional[AutoProcessor] = None
 
 
 def load_qwen3vl(
     model_name: str = "Qwen/Qwen3-VL-2B-Instruct",
     device: str = "cpu",
-) -> Tuple[Qwen2_5_VLForConditionalGeneration, AutoProcessor]:
+) -> Tuple[Qwen3VLForConditionalGeneration, AutoProcessor]:
     """
     Lazily load Qwen3-VL model and processor (cached at module level).
 
-    Qwen3-VL uses the Qwen2_5_VL* classes from transformers.
     Model is loaded in bfloat16 to reduce memory pressure.
 
     Args:
@@ -58,7 +57,7 @@ def load_qwen3vl(
         _processor = AutoProcessor.from_pretrained(model_name)
 
         print(f"[token_map] Loading Qwen3-VL model (bfloat16) on {device}...")
-        _model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
+        _model = Qwen3VLForConditionalGeneration.from_pretrained(
             model_name,
             torch_dtype=torch.bfloat16,
         ).to(device)

--- a/src/token_map.py
+++ b/src/token_map.py
@@ -208,9 +208,10 @@ def find_qwen3vl_image_tokens(
 # ---------------------------------------------------------------------------
 
 def bb_to_token_indices(
-    image_path: str,
-    bbs: List[Tuple[int, int, int, int]],
-    processor: AutoProcessor,
+    image_path: Optional[str] = None,
+    pil_image: Optional[Image.Image] = None,
+    bbs: List[Tuple[int, int, int, int]] = [],
+    processor: Optional[AutoProcessor] = None,
     device: str = "cpu",
 ) -> List[List[int]]:
     """
@@ -220,7 +221,8 @@ def bb_to_token_indices(
     the processed resolution and converted to patch-grid positions.
 
     Args:
-        image_path: Path to the table image.
+        image_path: Path to the table image (provide this OR pil_image).
+        pil_image:  PIL Image object (alternative to image_path).
         bbs:        List of (x1, y1, x2, y2) bboxes from OCR.
         processor:  Loaded AutoProcessor for Qwen3-VL.
         device:     Torch device string.
@@ -232,19 +234,25 @@ def bb_to_token_indices(
     # during unit-test stubs — the real pipeline will always have it.
     from qwen_vl_utils import process_vision_info  # type: ignore
 
-    if not Path(image_path).exists():
-        raise FileNotFoundError(f"[token_map] Image not found: {image_path}")
+    if pil_image is not None:
+        img = pil_image.convert("RGB")
+    elif image_path is not None:
+        if not Path(image_path).exists():
+            raise FileNotFoundError(f"[token_map] Image not found: {image_path}")
+        img = Image.open(image_path).convert("RGB")
+    else:
+        raise ValueError("Must provide either image_path or pil_image")
 
-    pil_image = Image.open(image_path).convert("RGB")
-    orig_w, orig_h = pil_image.size
+    orig_w, orig_h = img.size
     print(f"[token_map] Original image size: {orig_w}x{orig_h}")
 
     # --- Build minimal prompt following Qwen3-VL docs ---
+    # Use PIL image directly in the message for both file and PIL paths
     messages = [
         {
             "role": "user",
             "content": [
-                {"type": "image", "image": f"file://{image_path}"},
+                {"type": "image", "image": img},
                 {"type": "text", "text": "Describe this table."},
             ],
         }

--- a/src/train_qwen_cosyn.py
+++ b/src/train_qwen_cosyn.py
@@ -1,16 +1,28 @@
 """
 train_qwen_cosyn.py
 
-Custom training loop for fine-tuning Qwen3-VL on the CoSyn-400K table dataset.
-Designed to be extensible for auxiliary alignment loss:
-    loss = task_loss + w * alignment_loss
+Custom training loop for fine-tuning Qwen3-VL on the CoSyn-400K table dataset
+with auxiliary alignment loss. The alignment loss encourages visual token
+representations at a specific LM layer to match precomputed text-only
+representations for the same table cell content.
+
+    loss = task_loss + alignment_loss_weight * alignment_loss
+
+Design decisions (per Sameen, 2026-04-22):
+  - Raw L2 distance (MSE) on unnormalized hidden states, cast to fp32
+  - Freeze vision encoder + MLP; only LM layers are trainable
+  - Forward hook on a single layer (saves ~350MB vs output_hidden_states=True)
+  - use_reentrant=False for gradient checkpointing (HF issue #21381)
 """
 
 import argparse
-from dataclasses import dataclass, field
+import hashlib
+from dataclasses import dataclass
+from glob import glob as glob_files
 from typing import List, Dict, Any, Optional
 
 import torch
+import torch.nn.functional as F
 from torch.utils.data import Dataset, DataLoader
 from torch.nn.utils.rnn import pad_sequence
 from torch.nn.utils import clip_grad_norm_
@@ -24,6 +36,12 @@ from datasets import load_dataset
 from accelerate import Accelerator
 from accelerate.utils import set_seed
 from qwen_vl_utils import process_vision_info
+
+from src.token_map import (
+    get_processed_resolution,
+    scale_bbox,
+    find_qwen3vl_image_tokens,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -46,33 +64,91 @@ class Config:
     max_seq_len: int = 2048
     max_grad_norm: float = 1.0
     log_every: int = 50
-    # Placeholder for future auxiliary alignment loss.
-    # When alignment_loss_weight > 0, a hook should populate alignment_loss
-    # and total loss becomes: loss = task_loss + alignment_loss_weight * alignment_loss
-    alignment_loss_weight: float = 0.0
+    # Alignment loss config
+    alignment_loss_weight: float = 0.01
+    precomputed_dir: str = "data/preprocessed"
+    alignment_layer: int = 16
 
 
 # ---------------------------------------------------------------------------
 # 2. Dataset
 # ---------------------------------------------------------------------------
 
+def _image_hash(pil_image) -> str:
+    """Short SHA256 hash of PIL image bytes for matching precomputed data."""
+    return hashlib.sha256(pil_image.tobytes()).hexdigest()[:16]
+
+
 class CoSynTableDataset(Dataset):
     """
     Each CoSyn-400K row contains one image and a list of qa_pairs.
     We expand so every (image, qa_pair) becomes one independent training item.
-    This gives us maximum supervision signal per image.
+
+    If precomputed_dir is provided, loads alignment data (.pt files) and
+    matches them to dataset rows via image hash.
     """
 
-    def __init__(self, hf_split, processor, max_seq_len: int):
+    def __init__(
+        self,
+        hf_split,
+        processor,
+        max_seq_len: int,
+        precomputed_dir: Optional[str] = None,
+        alignment_layer: int = 16,
+    ):
         self.processor = processor
         self.max_seq_len = max_seq_len
         self.items: List[Dict[str, Any]] = []
 
+        # --- Load precomputed alignment data ---
+        self.hash_to_alignment: Dict[str, Dict[str, Any]] = {}
+        if precomputed_dir:
+            pt_files = sorted(glob_files(f"{precomputed_dir}/*.pt"))
+            if pt_files:
+                # Verify processor config on first file
+                sample_pt = torch.load(pt_files[0], weights_only=False)
+                pc = sample_pt["processor_config"]
+                proc_min = getattr(processor.image_processor, "min_pixels", None)
+                proc_max = getattr(processor.image_processor, "max_pixels", None)
+                assert pc["min_pixels"] == proc_min, (
+                    f"Processor min_pixels mismatch: .pt={pc['min_pixels']}, "
+                    f"current={proc_min}"
+                )
+                assert pc["max_pixels"] == proc_max, (
+                    f"Processor max_pixels mismatch: .pt={pc['max_pixels']}, "
+                    f"current={proc_max}"
+                )
+                print("[dataset] Processor config verified against precomputed data")
+
+                for pt_path in pt_files:
+                    pt = torch.load(pt_path, weights_only=False)
+                    self.hash_to_alignment[pt["image_hash"]] = {
+                        "bboxes": pt["bboxes"],
+                        # Only keep the layer we need: [num_cells, hidden_dim]
+                        "text_reps": pt["text_hidden_states"][
+                            :, alignment_layer, :
+                        ].clone(),
+                        "image_size": pt["image_size"],
+                    }
+                print(
+                    f"[dataset] Loaded {len(self.hash_to_alignment)} "
+                    f"precomputed alignment files"
+                )
+
+        # --- Expand rows into (image, qa_pair) items ---
+        compute_hash = bool(self.hash_to_alignment)
+        alignment_matches = 0
+
         for row in hf_split:
-            image = row["image"]  # PIL Image
+            image = row["image"]
             qa_pairs = row.get("qa_pairs", [])
             if not qa_pairs:
                 continue
+
+            img_hash = _image_hash(image) if compute_hash else ""
+            if img_hash in self.hash_to_alignment:
+                alignment_matches += 1
+
             for qa in qa_pairs:
                 question = qa.get("question", "")
                 answer = qa.get("answer", "")
@@ -82,12 +158,18 @@ class CoSynTableDataset(Dataset):
                     "image": image,
                     "question": question,
                     "answer": answer,
+                    "image_hash": img_hash,
                 })
+
+        if compute_hash:
+            print(
+                f"[dataset] {alignment_matches} images matched precomputed data"
+            )
 
     def __len__(self) -> int:
         return len(self.items)
 
-    def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
+    def __getitem__(self, idx: int) -> Dict[str, Any]:
         item = self.items[idx]
         image = item["image"]
         question = item["question"]
@@ -109,8 +191,6 @@ class CoSynTableDataset(Dataset):
         ]
 
         # --- Build prompt-only conversation (for label masking) ---
-        # apply_chat_template with add_generation_prompt=True gives us exactly
-        # the text up to where the model should start generating.
         messages_prompt = [
             {
                 "role": "user",
@@ -121,22 +201,18 @@ class CoSynTableDataset(Dataset):
             },
         ]
 
-        # Full text (user + assistant turn)
         full_text = self.processor.apply_chat_template(
             messages_full,
             tokenize=False,
             add_generation_prompt=False,
         )
-
-        # Prompt-only text (user turn + generation prompt marker)
         prompt_text = self.processor.apply_chat_template(
             messages_prompt,
             tokenize=False,
             add_generation_prompt=True,
         )
 
-        # Process images via qwen_vl_utils — returns image tensors in the
-        # format Qwen2.5-VL expects (pixel_values, image_grid_thw)
+        # Process images via qwen_vl_utils
         image_inputs, _ = process_vision_info(messages_full)
 
         # Encode full sequence
@@ -148,14 +224,12 @@ class CoSynTableDataset(Dataset):
             max_length=self.max_seq_len,
         )
 
-        input_ids = encoded["input_ids"].squeeze(0)           # (seq_len,)
-        attention_mask = encoded["attention_mask"].squeeze(0) # (seq_len,)
-        pixel_values = encoded["pixel_values"]                # (n_patches, C, H, W) — keep batch dim for cat
-        image_grid_thw = encoded["image_grid_thw"]            # (n_images, 3) — keep batch dim for cat
+        input_ids = encoded["input_ids"].squeeze(0)
+        attention_mask = encoded["attention_mask"].squeeze(0)
+        pixel_values = encoded["pixel_values"]
+        image_grid_thw = encoded["image_grid_thw"]
 
         # --- Build labels: mask the prompt prefix with -100 ---
-        # Tokenize the prompt-only text to get prompt length.
-        # We re-use the same image so the visual tokens are counted correctly.
         prompt_encoded = self.processor(
             text=[prompt_text],
             images=image_inputs,
@@ -166,9 +240,9 @@ class CoSynTableDataset(Dataset):
         prompt_len = prompt_encoded["input_ids"].shape[1]
 
         labels = input_ids.clone()
-        labels[:prompt_len] = -100  # mask prompt tokens — only supervise on answer
+        labels[:prompt_len] = -100
 
-        return {
+        result = {
             "input_ids": input_ids,
             "attention_mask": attention_mask,
             "labels": labels,
@@ -176,16 +250,30 @@ class CoSynTableDataset(Dataset):
             "image_grid_thw": image_grid_thw,
         }
 
+        # --- Alignment data (if available for this image) ---
+        img_hash = item["image_hash"]
+        if img_hash in self.hash_to_alignment:
+            align = self.hash_to_alignment[img_hash]
+            result["has_alignment"] = True
+            result["alignment_bboxes"] = align["bboxes"]
+            result["alignment_text_reps"] = align["text_reps"]
+            result["alignment_image_size"] = align["image_size"]
+        else:
+            result["has_alignment"] = False
+
+        return result
+
 
 # ---------------------------------------------------------------------------
 # 3. Collate function
 # ---------------------------------------------------------------------------
 
-def collate_fn(batch: List[Dict[str, Any]], pad_token_id: int) -> Dict[str, torch.Tensor]:
+def collate_fn(
+    batch: List[Dict[str, Any]], pad_token_id: int
+) -> Dict[str, Any]:
     """
-    pixel_values and image_grid_thw are concatenated along dim 0 because
-    Qwen2.5-VL expects a flat list of patches across the whole batch.
-    Sequences are right-padded.
+    Collate model inputs (padded/concatenated tensors) and alignment metadata
+    (passed through as Python lists).
     """
     input_ids = pad_sequence(
         [item["input_ids"] for item in batch],
@@ -203,9 +291,11 @@ def collate_fn(batch: List[Dict[str, Any]], pad_token_id: int) -> Dict[str, torc
         padding_value=-100,
     )
     pixel_values = torch.cat([item["pixel_values"] for item in batch], dim=0)
-    image_grid_thw = torch.cat([item["image_grid_thw"] for item in batch], dim=0)
+    image_grid_thw = torch.cat(
+        [item["image_grid_thw"] for item in batch], dim=0
+    )
 
-    return {
+    result = {
         "input_ids": input_ids,
         "attention_mask": attention_mask,
         "labels": labels,
@@ -213,9 +303,102 @@ def collate_fn(batch: List[Dict[str, Any]], pad_token_id: int) -> Dict[str, torc
         "image_grid_thw": image_grid_thw,
     }
 
+    # Alignment metadata — not tensors, passed through as lists
+    result["has_alignment"] = [
+        item.get("has_alignment", False) for item in batch
+    ]
+    result["alignment_bboxes"] = [
+        item.get("alignment_bboxes", []) for item in batch
+    ]
+    result["alignment_text_reps"] = [
+        item.get("alignment_text_reps", None) for item in batch
+    ]
+    result["alignment_image_size"] = [
+        item.get("alignment_image_size", (0, 0)) for item in batch
+    ]
+
+    return result
+
 
 # ---------------------------------------------------------------------------
-# 4. Validation
+# 4. Alignment loss computation
+# ---------------------------------------------------------------------------
+
+def compute_alignment_loss(
+    layer_hidden: torch.Tensor,
+    batch: Dict[str, Any],
+    image_grid_thw: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Compute raw L2 (MSE) alignment loss between visual token representations
+    at the hooked layer and precomputed text-only representations.
+
+    For each image with alignment data:
+      1. Scale OCR bboxes to the processor's resolution
+      2. Map bboxes → visual token indices in the sequence
+      3. Mean-pool hidden states at those positions → visual_rep
+      4. Compare to precomputed text_rep via MSE in fp32
+
+    Args:
+        layer_hidden: Hidden states from hooked layer [batch, seq_len, hidden_dim].
+        batch: Dict with alignment metadata (has_alignment, bboxes, text_reps, etc).
+        image_grid_thw: Image grid tensor [batch, 3] for resolution computation.
+
+    Returns:
+        Scalar MSE loss in fp32, or 0.0 if no alignment data in this batch.
+    """
+    visual_reps = []
+    text_reps = []
+
+    for i in range(layer_hidden.shape[0]):
+        if not batch["has_alignment"][i]:
+            continue
+
+        bboxes = batch["alignment_bboxes"][i]
+        text_reps_i = batch["alignment_text_reps"][i]  # [num_cells, hidden_dim]
+        orig_w, orig_h = batch["alignment_image_size"][i]
+
+        # Processed resolution for this image
+        processed_h, processed_w = get_processed_resolution(
+            image_grid_thw[i : i + 1], image_index=0
+        )
+
+        input_ids_i = batch["input_ids"][i]  # [seq_len]
+        seq_len = layer_hidden.shape[1]
+
+        for j, bbox in enumerate(bboxes):
+            scaled = scale_bbox(bbox, orig_w, orig_h, processed_w, processed_h)
+            token_indices = find_qwen3vl_image_tokens(
+                input_ids_i,
+                image_grid_thw[i : i + 1],
+                scaled,
+                image_index=0,
+            )
+
+            # Safety: clamp to actual sequence length (padded sequences)
+            valid_indices = [idx for idx in token_indices if idx < seq_len]
+            if not valid_indices:
+                continue
+
+            # Mean-pool visual hidden states at this cell's token positions
+            visual_tokens = layer_hidden[i, valid_indices, :]
+            visual_rep = visual_tokens.mean(dim=0)
+
+            visual_reps.append(visual_rep)
+            text_reps.append(text_reps_i[j])
+
+    if not visual_reps:
+        return torch.tensor(0.0, device=layer_hidden.device, requires_grad=False)
+
+    # Raw L2 (MSE) in fp32 for numerical stability
+    visual_stack = torch.stack(visual_reps).float()
+    text_stack = torch.stack(text_reps).to(visual_stack.device).float()
+
+    return F.mse_loss(visual_stack, text_stack)
+
+
+# ---------------------------------------------------------------------------
+# 5. Validation
 # ---------------------------------------------------------------------------
 
 def run_validation(model, val_loader, accelerator) -> float:
@@ -229,8 +412,16 @@ def run_validation(model, val_loader, accelerator) -> float:
 
     with torch.no_grad():
         for batch in val_loader:
+            # Remove alignment metadata before passing to model
+            for key in [
+                "has_alignment",
+                "alignment_bboxes",
+                "alignment_text_reps",
+                "alignment_image_size",
+            ]:
+                batch.pop(key, None)
+
             outputs = model(**batch)
-            # outputs.loss is mean over non-masked tokens in the batch
             non_masked = (batch["labels"] != -100).sum().item()
             total_loss += outputs.loss.item() * non_masked
             total_tokens += non_masked
@@ -241,13 +432,17 @@ def run_validation(model, val_loader, accelerator) -> float:
     total_loss_tensor = accelerator.reduce(total_loss_tensor, reduction="sum")
     total_tokens_tensor = accelerator.reduce(total_tokens_tensor, reduction="sum")
 
-    avg_loss = (total_loss_tensor / total_tokens_tensor).item() if total_tokens_tensor > 0 else float("inf")
+    avg_loss = (
+        (total_loss_tensor / total_tokens_tensor).item()
+        if total_tokens_tensor > 0
+        else float("inf")
+    )
     model.train()
     return avg_loss
 
 
 # ---------------------------------------------------------------------------
-# 5. Main training loop
+# 6. Main training loop
 # ---------------------------------------------------------------------------
 
 def main(config: Config):
@@ -261,6 +456,7 @@ def main(config: Config):
 
     if accelerator.is_main_process:
         import os
+
         os.makedirs(config.output_dir, exist_ok=True)
 
     print(f"[train] Using device: {accelerator.device}")
@@ -269,7 +465,9 @@ def main(config: Config):
 
     # --- Load processor and model ---
     print(f"[train] Loading processor and model: {config.model_name}")
-    processor = AutoProcessor.from_pretrained(config.model_name, trust_remote_code=True)
+    processor = AutoProcessor.from_pretrained(
+        config.model_name, trust_remote_code=True
+    )
 
     model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
         config.model_name,
@@ -277,18 +475,60 @@ def main(config: Config):
         attn_implementation="flash_attention_2",
         trust_remote_code=True,
     )
-    model.gradient_checkpointing_enable()
+
+    # --- Freeze vision encoder + MLP (per Sameen, 2026-04-22) ---
+    # Only the LM layers (model.model.layers, embed_tokens, norm, lm_head) train.
+    model.visual.requires_grad_(False)
+    frozen_params = sum(p.numel() for p in model.visual.parameters())
+    trainable_params = sum(
+        p.numel() for p in model.parameters() if p.requires_grad
+    )
+    total_params = sum(p.numel() for p in model.parameters())
+    print(f"[train] Frozen (visual): {frozen_params:,} params")
+    print(
+        f"[train] Trainable (LM): {trainable_params:,} / {total_params:,} total"
+    )
+
+    # use_reentrant=False is required when some params are frozen (HF #21381)
+    model.gradient_checkpointing_enable(
+        gradient_checkpointing_kwargs={"use_reentrant": False}
+    )
+
+    # --- Register forward hook for alignment loss ---
+    # Captures hidden states from a single LM layer without retaining all 28
+    # layers (~350MB VRAM savings vs output_hidden_states=True).
+    # Tensor is NOT detached — gradients flow through the LM layers.
+    captured_hidden: Dict[str, torch.Tensor] = {}
+    hook_handle = None
+
+    if config.alignment_loss_weight > 0:
+
+        def alignment_hook(module, input, output):
+            # output is a tuple; output[0] is the hidden state tensor
+            captured_hidden["hidden"] = output[0]
+
+        hook_handle = model.model.layers[
+            config.alignment_layer
+        ].register_forward_hook(alignment_hook)
+        print(
+            f"[train] Alignment hook registered on layer {config.alignment_layer}"
+        )
+        print(f"[train] Alignment loss weight: {config.alignment_loss_weight}")
 
     # --- Load dataset ---
-    print(f"[train] Loading dataset: {config.dataset_name} (config={config.dataset_config})")
+    print(
+        f"[train] Loading dataset: {config.dataset_name} "
+        f"(config={config.dataset_config})"
+    )
     raw = load_dataset(config.dataset_name, config.dataset_config)
 
-    # CoSyn-400K may only have a 'train' split; create a small val split if needed
     if "validation" in raw:
         train_split = raw["train"]
         val_split = raw["validation"]
     else:
-        split = raw["train"].train_test_split(test_size=0.02, seed=config.seed)
+        split = raw["train"].train_test_split(
+            test_size=0.02, seed=config.seed
+        )
         train_split = split["train"]
         val_split = split["test"]
 
@@ -296,9 +536,21 @@ def main(config: Config):
 
     # --- Build datasets ---
     print("[train] Building CoSynTableDataset (expanding qa_pairs)...")
-    train_dataset = CoSynTableDataset(train_split, processor, config.max_seq_len)
+    precomputed = (
+        config.precomputed_dir if config.alignment_loss_weight > 0 else None
+    )
+    train_dataset = CoSynTableDataset(
+        train_split,
+        processor,
+        config.max_seq_len,
+        precomputed_dir=precomputed,
+        alignment_layer=config.alignment_layer,
+    )
     val_dataset = CoSynTableDataset(val_split, processor, config.max_seq_len)
-    print(f"[train] Train items (expanded): {len(train_dataset)} | Val items: {len(val_dataset)}")
+    print(
+        f"[train] Train items (expanded): {len(train_dataset)} "
+        f"| Val items: {len(val_dataset)}"
+    )
 
     pad_id = processor.tokenizer.pad_token_id
 
@@ -319,15 +571,17 @@ def main(config: Config):
         pin_memory=True,
     )
 
-    # --- Optimizer and scheduler ---
+    # --- Optimizer (only trainable params) ---
     optimizer = torch.optim.AdamW(
-        model.parameters(),
+        filter(lambda p: p.requires_grad, model.parameters()),
         lr=config.lr,
         weight_decay=config.weight_decay,
         betas=(0.9, 0.95),
     )
 
-    total_steps = (len(train_loader) // config.grad_accum_steps) * config.num_epochs
+    total_steps = (
+        (len(train_loader) // config.grad_accum_steps) * config.num_epochs
+    )
     warmup_steps = int(total_steps * config.warmup_ratio)
     scheduler = get_cosine_schedule_with_warmup(
         optimizer,
@@ -335,7 +589,10 @@ def main(config: Config):
         num_training_steps=total_steps,
     )
 
-    print(f"[train] Total optimizer steps: {total_steps} | Warmup steps: {warmup_steps}")
+    print(
+        f"[train] Total optimizer steps: {total_steps} "
+        f"| Warmup steps: {warmup_steps}"
+    )
 
     # --- Accelerator prepare ---
     model, optimizer, train_loader, val_loader, scheduler = accelerator.prepare(
@@ -348,23 +605,47 @@ def main(config: Config):
 
     for epoch in range(1, config.num_epochs + 1):
         model.train()
-        running_loss = 0.0
+        running_task_loss = 0.0
+        running_align_loss = 0.0
 
         for step, batch in enumerate(train_loader, start=1):
             with accelerator.accumulate(model):
-                # Forward pass
+                # Separate alignment metadata before passing to model
+                has_alignment = batch.pop("has_alignment")
+                alignment_bboxes = batch.pop("alignment_bboxes")
+                alignment_text_reps = batch.pop("alignment_text_reps")
+                alignment_image_size = batch.pop("alignment_image_size")
+
+                # Keep a copy for alignment computation (before model consumes it)
+                image_grid_thw_raw = batch["image_grid_thw"].clone()
+
+                # Forward pass — hook captures layer hidden states
                 outputs = model(**batch)
                 task_loss = outputs.loss
 
-                # ----------------------------------------------------------------
-                # ALIGNMENT LOSS HOOK
-                # When alignment_loss_weight > 0, compute alignment_loss here
-                # using intermediate representations (e.g., cross-modal cosine loss)
-                # and combine:
-                #     alignment_loss = compute_alignment_loss(model, batch, outputs)
-                #     loss = task_loss + config.alignment_loss_weight * alignment_loss
-                # ----------------------------------------------------------------
-                alignment_loss = torch.tensor(0.0, device=task_loss.device)
+                # --- Alignment loss ---
+                if (
+                    config.alignment_loss_weight > 0
+                    and "hidden" in captured_hidden
+                    and any(has_alignment)
+                ):
+                    align_batch = {
+                        "has_alignment": has_alignment,
+                        "alignment_bboxes": alignment_bboxes,
+                        "alignment_text_reps": alignment_text_reps,
+                        "alignment_image_size": alignment_image_size,
+                        "input_ids": batch["input_ids"],
+                    }
+                    alignment_loss = compute_alignment_loss(
+                        captured_hidden["hidden"],
+                        align_batch,
+                        image_grid_thw_raw,
+                    )
+                    captured_hidden.clear()
+                else:
+                    alignment_loss = torch.tensor(0.0, device=task_loss.device)
+                    captured_hidden.clear()
+
                 loss = task_loss + config.alignment_loss_weight * alignment_loss
 
                 accelerator.backward(loss)
@@ -376,19 +657,27 @@ def main(config: Config):
                 scheduler.step()
                 optimizer.zero_grad()
 
-            running_loss += loss.detach().item()
+            running_task_loss += task_loss.detach().item()
+            running_align_loss += alignment_loss.detach().item()
 
             if accelerator.sync_gradients:
                 global_step += 1
 
-                if global_step % config.log_every == 0 and accelerator.is_main_process:
-                    avg = running_loss / config.log_every
+                if (
+                    global_step % config.log_every == 0
+                    and accelerator.is_main_process
+                ):
+                    avg_task = running_task_loss / config.log_every
+                    avg_align = running_align_loss / config.log_every
                     lr_now = scheduler.get_last_lr()[0]
                     print(
                         f"[train] epoch={epoch} step={global_step} "
-                        f"loss={avg:.4f} lr={lr_now:.2e}"
+                        f"task_loss={avg_task:.4f} "
+                        f"align_loss={avg_align:.4f} "
+                        f"lr={lr_now:.2e}"
                     )
-                    running_loss = 0.0
+                    running_task_loss = 0.0
+                    running_align_loss = 0.0
 
         # --- Validation at end of each epoch ---
         print(f"[train] Running validation after epoch {epoch}...")
@@ -400,10 +689,17 @@ def main(config: Config):
             if val_loss < best_val_loss:
                 best_val_loss = val_loss
                 save_path = f"{config.output_dir}/best_model"
-                print(f"[train] New best val_loss={best_val_loss:.4f} — saving to {save_path}")
+                print(
+                    f"[train] New best val_loss={best_val_loss:.4f} "
+                    f"— saving to {save_path}"
+                )
                 unwrapped = accelerator.unwrap_model(model)
                 unwrapped.save_pretrained(save_path)
                 processor.save_pretrained(save_path)
+
+    # --- Cleanup ---
+    if hook_handle is not None:
+        hook_handle.remove()
 
     if accelerator.is_main_process:
         print(f"[train] Training complete. Best val_loss={best_val_loss:.4f}")
@@ -411,27 +707,57 @@ def main(config: Config):
 
 
 # ---------------------------------------------------------------------------
-# 6. Entry point
+# 7. Entry point
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Fine-tune Qwen3-VL on CoSyn-400K table split")
+    parser = argparse.ArgumentParser(
+        description="Fine-tune Qwen3-VL on CoSyn-400K table split"
+    )
 
     parser.add_argument("--model_name", type=str, default=Config.model_name)
-    parser.add_argument("--dataset_name", type=str, default=Config.dataset_name)
-    parser.add_argument("--dataset_config", type=str, default=Config.dataset_config)
+    parser.add_argument(
+        "--dataset_name", type=str, default=Config.dataset_name
+    )
+    parser.add_argument(
+        "--dataset_config", type=str, default=Config.dataset_config
+    )
     parser.add_argument("--output_dir", type=str, default=Config.output_dir)
     parser.add_argument("--seed", type=int, default=Config.seed)
     parser.add_argument("--num_epochs", type=int, default=Config.num_epochs)
     parser.add_argument("--lr", type=float, default=Config.lr)
-    parser.add_argument("--weight_decay", type=float, default=Config.weight_decay)
-    parser.add_argument("--warmup_ratio", type=float, default=Config.warmup_ratio)
-    parser.add_argument("--per_device_batch_size", type=int, default=Config.per_device_batch_size)
-    parser.add_argument("--grad_accum_steps", type=int, default=Config.grad_accum_steps)
-    parser.add_argument("--max_seq_len", type=int, default=Config.max_seq_len)
-    parser.add_argument("--max_grad_norm", type=float, default=Config.max_grad_norm)
+    parser.add_argument(
+        "--weight_decay", type=float, default=Config.weight_decay
+    )
+    parser.add_argument(
+        "--warmup_ratio", type=float, default=Config.warmup_ratio
+    )
+    parser.add_argument(
+        "--per_device_batch_size",
+        type=int,
+        default=Config.per_device_batch_size,
+    )
+    parser.add_argument(
+        "--grad_accum_steps", type=int, default=Config.grad_accum_steps
+    )
+    parser.add_argument(
+        "--max_seq_len", type=int, default=Config.max_seq_len
+    )
+    parser.add_argument(
+        "--max_grad_norm", type=float, default=Config.max_grad_norm
+    )
     parser.add_argument("--log_every", type=int, default=Config.log_every)
-    parser.add_argument("--alignment_loss_weight", type=float, default=Config.alignment_loss_weight)
+    parser.add_argument(
+        "--alignment_loss_weight",
+        type=float,
+        default=Config.alignment_loss_weight,
+    )
+    parser.add_argument(
+        "--precomputed_dir", type=str, default=Config.precomputed_dir
+    )
+    parser.add_argument(
+        "--alignment_layer", type=int, default=Config.alignment_layer
+    )
 
     args = parser.parse_args()
     config = Config(**vars(args))

--- a/src/train_qwen_cosyn.py
+++ b/src/train_qwen_cosyn.py
@@ -61,11 +61,14 @@ class Config:
     warmup_ratio: float = 0.1
     per_device_batch_size: int = 2
     grad_accum_steps: int = 8
-    max_seq_len: int = 2048
+    max_seq_len: int = 4096
     max_grad_norm: float = 1.0
     log_every: int = 50
     # Alignment loss config
-    alignment_loss_weight: float = 0.01
+    # Calibrated 2026-04-27 on 30 CoSyn samples (layer 16, mean-pool MSE on raw
+    # bf16 hidden states): mean task=4.53, mean align=44,291. Per issue #5, w
+    # is set so w*align ~= 0.1*task on average.
+    alignment_loss_weight: float = 1.0e-5
     precomputed_dir: str = "data/preprocessed"
     alignment_layer: int = 16
 
@@ -141,17 +144,19 @@ class CoSynTableDataset(Dataset):
 
         for row in hf_split:
             image = row["image"]
-            qa_pairs = row.get("qa_pairs", [])
-            if not qa_pairs:
+            # CoSyn-400K stores qa_pairs as a dict-of-lists:
+            #   {'question': [...], 'explanation': [...], 'answer': [...]}
+            qa_pairs = row.get("qa_pairs", {}) or {}
+            questions = qa_pairs.get("question", []) if isinstance(qa_pairs, dict) else []
+            answers = qa_pairs.get("answer", []) if isinstance(qa_pairs, dict) else []
+            if not questions or not answers:
                 continue
 
             img_hash = _image_hash(image) if compute_hash else ""
             if img_hash in self.hash_to_alignment:
                 alignment_matches += 1
 
-            for qa in qa_pairs:
-                question = qa.get("question", "")
-                answer = qa.get("answer", "")
+            for question, answer in zip(questions, answers):
                 if not question or not answer:
                     continue
                 self.items.append({
@@ -169,7 +174,7 @@ class CoSynTableDataset(Dataset):
     def __len__(self) -> int:
         return len(self.items)
 
-    def __getitem__(self, idx: int) -> Dict[str, Any]:
+    def __getitem__(self, idx: int, _attempts: int = 0) -> Dict[str, Any]:
         item = self.items[idx]
         image = item["image"]
         question = item["question"]
@@ -215,17 +220,25 @@ class CoSynTableDataset(Dataset):
         # Process images via qwen_vl_utils
         image_inputs, _ = process_vision_info(messages_full)
 
-        # Encode full sequence
-        encoded = self.processor(
-            text=[full_text],
-            images=image_inputs,
-            return_tensors="pt",
-            truncation=True,
-            max_length=self.max_seq_len,
-        )
+        # Encode full sequence. Some CoSyn tables produce more image tokens
+        # than max_seq_len allows; truncation then mismatches the special-token
+        # count and the processor raises. Skip-ahead a few times before giving up.
+        try:
+            encoded = self.processor(
+                text=[full_text],
+                images=image_inputs,
+                return_tensors="pt",
+                truncation=True,
+                max_length=self.max_seq_len,
+            )
+        except ValueError:
+            if _attempts >= 5:
+                raise
+            return self.__getitem__((idx + 1) % len(self), _attempts + 1)
 
         input_ids = encoded["input_ids"].squeeze(0)
         attention_mask = encoded["attention_mask"].squeeze(0)
+        mm_token_type_ids = encoded["mm_token_type_ids"].squeeze(0)
         pixel_values = encoded["pixel_values"]
         image_grid_thw = encoded["image_grid_thw"]
 
@@ -245,6 +258,7 @@ class CoSynTableDataset(Dataset):
         result = {
             "input_ids": input_ids,
             "attention_mask": attention_mask,
+            "mm_token_type_ids": mm_token_type_ids,
             "labels": labels,
             "pixel_values": pixel_values,
             "image_grid_thw": image_grid_thw,
@@ -285,6 +299,11 @@ def collate_fn(
         batch_first=True,
         padding_value=0,
     )
+    mm_token_type_ids = pad_sequence(
+        [item["mm_token_type_ids"] for item in batch],
+        batch_first=True,
+        padding_value=0,  # 0 = text token; padded positions are masked by attention_mask
+    )
     labels = pad_sequence(
         [item["labels"] for item in batch],
         batch_first=True,
@@ -298,6 +317,7 @@ def collate_fn(
     result = {
         "input_ids": input_ids,
         "attention_mask": attention_mask,
+        "mm_token_type_ids": mm_token_type_ids,
         "labels": labels,
         "pixel_values": pixel_values,
         "image_grid_thw": image_grid_thw,

--- a/src/train_qwen_cosyn.py
+++ b/src/train_qwen_cosyn.py
@@ -71,6 +71,10 @@ class Config:
     alignment_loss_weight: float = 1.0e-5
     precomputed_dir: str = "data/preprocessed"
     alignment_layer: int = 16
+    # Runtime knobs
+    attn_implementation: str = "sdpa"  # "flash_attention_2" requires flash-attn install
+    num_train_samples: int = 0  # 0 = use full split; >0 = slice for smoke tests
+    num_val_samples: int = 0    # 0 = use full split; >0 = slice for smoke tests
 
 
 # ---------------------------------------------------------------------------
@@ -492,7 +496,7 @@ def main(config: Config):
     model = Qwen3VLForConditionalGeneration.from_pretrained(
         config.model_name,
         torch_dtype=torch.bfloat16,
-        attn_implementation="flash_attention_2",
+        attn_implementation=config.attn_implementation,
         trust_remote_code=True,
     )
 
@@ -553,6 +557,14 @@ def main(config: Config):
         )
         train_split = split["train"]
         val_split = split["test"]
+
+    # Optional slicing for smoke tests
+    if config.num_train_samples > 0:
+        n = min(config.num_train_samples, len(train_split))
+        train_split = train_split.select(range(n))
+    if config.num_val_samples > 0:
+        n = min(config.num_val_samples, len(val_split))
+        val_split = val_split.select(range(n))
 
     print(f"[train] Train rows: {len(train_split)} | Val rows: {len(val_split)}")
 
@@ -779,6 +791,24 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--alignment_layer", type=int, default=Config.alignment_layer
+    )
+    parser.add_argument(
+        "--attn_implementation",
+        type=str,
+        default=Config.attn_implementation,
+        help='Attention backend: "sdpa" (default), "flash_attention_2", "eager"',
+    )
+    parser.add_argument(
+        "--num_train_samples",
+        type=int,
+        default=Config.num_train_samples,
+        help="Slice train split to N rows (0 = full). Useful for smoke tests.",
+    )
+    parser.add_argument(
+        "--num_val_samples",
+        type=int,
+        default=Config.num_val_samples,
+        help="Slice val split to N rows (0 = full). Useful for smoke tests.",
     )
 
     args = parser.parse_args()

--- a/src/train_qwen_cosyn.py
+++ b/src/train_qwen_cosyn.py
@@ -29,7 +29,7 @@ from torch.nn.utils import clip_grad_norm_
 
 from transformers import (
     AutoProcessor,
-    Qwen2_5_VLForConditionalGeneration,
+    Qwen3VLForConditionalGeneration,
     get_cosine_schedule_with_warmup,
 )
 from datasets import load_dataset
@@ -469,7 +469,7 @@ def main(config: Config):
         config.model_name, trust_remote_code=True
     )
 
-    model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
+    model = Qwen3VLForConditionalGeneration.from_pretrained(
         config.model_name,
         torch_dtype=torch.bfloat16,
         attn_implementation="flash_attention_2",
@@ -477,9 +477,10 @@ def main(config: Config):
     )
 
     # --- Freeze vision encoder + MLP (per Sameen, 2026-04-22) ---
-    # Only the LM layers (model.model.layers, embed_tokens, norm, lm_head) train.
-    model.visual.requires_grad_(False)
-    frozen_params = sum(p.numel() for p in model.visual.parameters())
+    # Only the LM layers (model.model.language_model.layers, embed_tokens, norm,
+    # lm_head) train.
+    model.model.visual.requires_grad_(False)
+    frozen_params = sum(p.numel() for p in model.model.visual.parameters())
     trainable_params = sum(
         p.numel() for p in model.parameters() if p.requires_grad
     )
@@ -504,10 +505,11 @@ def main(config: Config):
     if config.alignment_loss_weight > 0:
 
         def alignment_hook(module, input, output):
-            # output is a tuple; output[0] is the hidden state tensor
-            captured_hidden["hidden"] = output[0]
+            # Qwen3VLTextDecoderLayer.forward returns the hidden state tensor
+            # directly (not a tuple), so we capture `output` as-is.
+            captured_hidden["hidden"] = output
 
-        hook_handle = model.model.layers[
+        hook_handle = model.model.language_model.layers[
             config.alignment_layer
         ].register_forward_hook(alignment_hook)
         print(

--- a/src/train_qwen_cosyn.py
+++ b/src/train_qwen_cosyn.py
@@ -42,6 +42,7 @@ from src.token_map import (
     scale_bbox,
     find_qwen3vl_image_tokens,
 )
+from src.losses import compute_lm_head_bow_loss
 
 
 # ---------------------------------------------------------------------------
@@ -71,6 +72,12 @@ class Config:
     alignment_loss_weight: float = 1.0e-5
     precomputed_dir: str = "data/preprocessed"
     alignment_layer: int = 16
+    # Alignment loss mode:
+    #   "mse"          — raw L2 between pooled visual rep and precomputed text rep (original spec)
+    #   "lm_head_bow"  — CE between lm_head(pooled visual rep) and OCR cell tokens (BoW)
+    alignment_loss_mode: str = "mse"
+    # If "lm_head_bow", optionally apply the final LM norm before lm_head
+    lm_head_bow_use_final_norm: bool = True
     # Runtime knobs
     attn_implementation: str = "sdpa"  # "flash_attention_2" requires flash-attn install
     num_train_samples: int = 0  # 0 = use full split; >0 = slice for smoke tests
@@ -129,6 +136,13 @@ class CoSynTableDataset(Dataset):
 
                 for pt_path in pt_files:
                     pt = torch.load(pt_path, weights_only=False)
+                    cell_texts = pt.get("texts", [])
+                    # Pre-tokenize cell texts for lm_head_bow loss (no special tokens).
+                    # Cheap on CPU and avoids re-tokenizing every epoch.
+                    cell_token_ids = [
+                        processor.tokenizer.encode(t or "", add_special_tokens=False)
+                        for t in cell_texts
+                    ]
                     self.hash_to_alignment[pt["image_hash"]] = {
                         "bboxes": pt["bboxes"],
                         # Only keep the layer we need: [num_cells, hidden_dim]
@@ -136,6 +150,7 @@ class CoSynTableDataset(Dataset):
                             :, alignment_layer, :
                         ].clone(),
                         "image_size": pt["image_size"],
+                        "cell_token_ids": cell_token_ids,
                     }
                 print(
                     f"[dataset] Loaded {len(self.hash_to_alignment)} "
@@ -276,6 +291,7 @@ class CoSynTableDataset(Dataset):
             result["alignment_bboxes"] = align["bboxes"]
             result["alignment_text_reps"] = align["text_reps"]
             result["alignment_image_size"] = align["image_size"]
+            result["alignment_cell_token_ids"] = align["cell_token_ids"]
         else:
             result["has_alignment"] = False
 
@@ -340,6 +356,9 @@ def collate_fn(
     result["alignment_image_size"] = [
         item.get("alignment_image_size", (0, 0)) for item in batch
     ]
+    result["alignment_cell_token_ids"] = [
+        item.get("alignment_cell_token_ids", []) for item in batch
+    ]
 
     return result
 
@@ -352,27 +371,36 @@ def compute_alignment_loss(
     layer_hidden: torch.Tensor,
     batch: Dict[str, Any],
     image_grid_thw: torch.Tensor,
+    *,
+    mode: str = "mse",
+    lm_head: Optional[torch.nn.Module] = None,
+    final_norm: Optional[torch.nn.Module] = None,
 ) -> torch.Tensor:
     """
-    Compute raw L2 (MSE) alignment loss between visual token representations
-    at the hooked layer and precomputed text-only representations.
+    Per-cell alignment loss. Steps shared across modes:
+      1. Scale OCR bboxes to the processor's resolution.
+      2. Map bboxes → visual token indices in the sequence.
+      3. Mean-pool hidden states at those positions → per-cell visual_rep.
 
-    For each image with alignment data:
-      1. Scale OCR bboxes to the processor's resolution
-      2. Map bboxes → visual token indices in the sequence
-      3. Mean-pool hidden states at those positions → visual_rep
-      4. Compare to precomputed text_rep via MSE in fp32
+    Per-cell target depends on `mode`:
+      - "mse":         compare visual_rep to precomputed text_rep with MSE (fp32).
+      - "lm_head_bow": decode visual_rep through (detached) lm_head; CE against
+                       OCR cell tokens as a bag-of-words.
 
     Args:
-        layer_hidden: Hidden states from hooked layer [batch, seq_len, hidden_dim].
-        batch: Dict with alignment metadata (has_alignment, bboxes, text_reps, etc).
-        image_grid_thw: Image grid tensor [batch, 3] for resolution computation.
+        layer_hidden:    [batch, seq_len, hidden_dim] from the hooked LM layer.
+        batch:           dict with alignment metadata.
+        image_grid_thw:  [batch, 3] image grid tensor.
+        mode:            "mse" or "lm_head_bow".
+        lm_head:         required when mode == "lm_head_bow".
+        final_norm:      optional final LM norm to apply before lm_head.
 
     Returns:
-        Scalar MSE loss in fp32, or 0.0 if no alignment data in this batch.
+        Scalar loss, or 0.0 if no alignment data in this batch.
     """
     visual_reps = []
     text_reps = []
+    cell_token_ids: List[List[int]] = []
 
     for i in range(layer_hidden.shape[0]):
         if not batch["has_alignment"][i]:
@@ -380,6 +408,7 @@ def compute_alignment_loss(
 
         bboxes = batch["alignment_bboxes"][i]
         text_reps_i = batch["alignment_text_reps"][i]  # [num_cells, hidden_dim]
+        token_ids_i = batch.get("alignment_cell_token_ids", [[]] * layer_hidden.shape[0])[i]
         orig_w, orig_h = batch["alignment_image_size"][i]
 
         # Processed resolution for this image
@@ -410,15 +439,31 @@ def compute_alignment_loss(
 
             visual_reps.append(visual_rep)
             text_reps.append(text_reps_i[j])
+            cell_token_ids.append(token_ids_i[j] if j < len(token_ids_i) else [])
 
     if not visual_reps:
         return torch.tensor(0.0, device=layer_hidden.device, requires_grad=False)
 
-    # Raw L2 (MSE) in fp32 for numerical stability
-    visual_stack = torch.stack(visual_reps).float()
-    text_stack = torch.stack(text_reps).to(visual_stack.device).float()
+    if mode == "mse":
+        # Raw L2 (MSE) in fp32 for numerical stability
+        visual_stack = torch.stack(visual_reps).float()
+        text_stack = torch.stack(text_reps).to(visual_stack.device).float()
+        return F.mse_loss(visual_stack, text_stack)
 
-    return F.mse_loss(visual_stack, text_stack)
+    elif mode == "lm_head_bow":
+        assert lm_head is not None, "lm_head required for mode='lm_head_bow'"
+        # Keep visual_stack in the model's compute dtype (bf16) — fp32 cast happens
+        # internally in compute_lm_head_bow_loss for the log_softmax.
+        visual_stack = torch.stack(visual_reps)
+        return compute_lm_head_bow_loss(
+            visual_reps=visual_stack,
+            cell_token_ids=cell_token_ids,
+            lm_head=lm_head,
+            final_norm=final_norm,
+        )
+
+    else:
+        raise ValueError(f"Unknown alignment_loss_mode: '{mode}'")
 
 
 # ---------------------------------------------------------------------------
@@ -442,6 +487,7 @@ def run_validation(model, val_loader, accelerator) -> float:
                 "alignment_bboxes",
                 "alignment_text_reps",
                 "alignment_image_size",
+                "alignment_cell_token_ids",
             ]:
                 batch.pop(key, None)
 
@@ -525,6 +571,8 @@ def main(config: Config):
     # Tensor is NOT detached — gradients flow through the LM layers.
     captured_hidden: Dict[str, torch.Tensor] = {}
     hook_handle = None
+    lm_head_module = None
+    final_norm_module = None
 
     if config.alignment_loss_weight > 0:
 
@@ -540,6 +588,21 @@ def main(config: Config):
             f"[train] Alignment hook registered on layer {config.alignment_layer}"
         )
         print(f"[train] Alignment loss weight: {config.alignment_loss_weight}")
+        print(f"[train] Alignment loss mode: {config.alignment_loss_mode}")
+
+        if config.alignment_loss_mode == "lm_head_bow":
+            # Resolve lm_head and final norm modules. Qwen3-VL exposes lm_head at
+            # the top level; the final pre-head norm lives inside the LM submodule.
+            lm_head_module = model.lm_head
+            if config.lm_head_bow_use_final_norm:
+                final_norm_module = getattr(model.model.language_model, "norm", None)
+                if final_norm_module is None:
+                    print("[train] WARNING: lm_head_bow_use_final_norm=True but no "
+                          "language_model.norm found; proceeding without it.")
+            print(
+                f"[train] lm_head_bow: lm_head={type(lm_head_module).__name__}, "
+                f"final_norm={'on' if final_norm_module is not None else 'off'}"
+            )
 
     # --- Load dataset ---
     print(
@@ -649,6 +712,7 @@ def main(config: Config):
                 alignment_bboxes = batch.pop("alignment_bboxes")
                 alignment_text_reps = batch.pop("alignment_text_reps")
                 alignment_image_size = batch.pop("alignment_image_size")
+                alignment_cell_token_ids = batch.pop("alignment_cell_token_ids")
 
                 # Keep a copy for alignment computation (before model consumes it)
                 image_grid_thw_raw = batch["image_grid_thw"].clone()
@@ -668,12 +732,16 @@ def main(config: Config):
                         "alignment_bboxes": alignment_bboxes,
                         "alignment_text_reps": alignment_text_reps,
                         "alignment_image_size": alignment_image_size,
+                        "alignment_cell_token_ids": alignment_cell_token_ids,
                         "input_ids": batch["input_ids"],
                     }
                     alignment_loss = compute_alignment_loss(
                         captured_hidden["hidden"],
                         align_batch,
                         image_grid_thw_raw,
+                        mode=config.alignment_loss_mode,
+                        lm_head=lm_head_module,
+                        final_norm=final_norm_module,
                     )
                     captured_hidden.clear()
                 else:
@@ -791,6 +859,22 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--alignment_layer", type=int, default=Config.alignment_layer
+    )
+    parser.add_argument(
+        "--alignment_loss_mode",
+        type=str,
+        default=Config.alignment_loss_mode,
+        choices=["mse", "lm_head_bow"],
+        help='Alignment loss formulation. "mse" matches the original spec; '
+             '"lm_head_bow" decodes pooled visual reps via frozen lm_head and CE '
+             'against OCR cell tokens (bag-of-words).',
+    )
+    parser.add_argument(
+        "--lm_head_bow_use_final_norm",
+        action=argparse.BooleanOptionalAction,
+        default=Config.lm_head_bow_use_final_norm,
+        help="When --alignment_loss_mode=lm_head_bow, apply the final LM norm "
+             "(detached) before lm_head. Default on.",
     )
     parser.add_argument(
         "--attn_implementation",

--- a/src/train_qwen_cosyn.py
+++ b/src/train_qwen_cosyn.py
@@ -17,6 +17,9 @@ Design decisions (per Sameen, 2026-04-22):
 
 import argparse
 import hashlib
+import json
+import os
+import shutil
 from dataclasses import dataclass
 from glob import glob as glob_files
 from typing import List, Dict, Any, Optional
@@ -82,6 +85,14 @@ class Config:
     attn_implementation: str = "sdpa"  # "flash_attention_2" requires flash-attn install
     num_train_samples: int = 0  # 0 = use full split; >0 = slice for smoke tests
     num_val_samples: int = 0    # 0 = use full split; >0 = slice for smoke tests
+    # Mid-epoch checkpointing (0 = disabled, only end-of-epoch best_model save)
+    save_steps: int = 0
+    save_total_limit: int = 2
+    resume_from: str = ""
+    # Train only on items whose image has matching precomputed alignment data
+    # (every batch contributes alignment gradient). Val is always unfiltered
+    # so EM eval stays comparable across runs.
+    aligned_only: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -109,9 +120,11 @@ class CoSynTableDataset(Dataset):
         max_seq_len: int,
         precomputed_dir: Optional[str] = None,
         alignment_layer: int = 16,
+        aligned_only: bool = False,
     ):
         self.processor = processor
         self.max_seq_len = max_seq_len
+        self.aligned_only = aligned_only
         self.items: List[Dict[str, Any]] = []
 
         # --- Load precomputed alignment data ---
@@ -174,6 +187,9 @@ class CoSynTableDataset(Dataset):
             img_hash = _image_hash(image) if compute_hash else ""
             if img_hash in self.hash_to_alignment:
                 alignment_matches += 1
+            elif self.aligned_only:
+                # Skip rows whose image lacks precomputed alignment data
+                continue
 
             for question, answer in zip(questions, answers):
                 if not question or not answer:
@@ -642,6 +658,7 @@ def main(config: Config):
         config.max_seq_len,
         precomputed_dir=precomputed,
         alignment_layer=config.alignment_layer,
+        aligned_only=config.aligned_only,
     )
     val_dataset = CoSynTableDataset(val_split, processor, config.max_seq_len)
     print(
@@ -699,13 +716,50 @@ def main(config: Config):
     # --- Training loop ---
     best_val_loss = float("inf")
     global_step = 0
+    resume_epoch = 1
+
+    # --- Resume from checkpoint (if requested) ---
+    if config.resume_from:
+        if not os.path.isdir(config.resume_from):
+            raise FileNotFoundError(
+                f"--resume_from path does not exist: {config.resume_from}"
+            )
+        print(f"[train] Resuming from {config.resume_from}")
+        accelerator.load_state(config.resume_from)
+        state_path = os.path.join(config.resume_from, "training_state.json")
+        if os.path.exists(state_path):
+            with open(state_path) as f:
+                state = json.load(f)
+            global_step = int(state.get("global_step", 0))
+            resume_epoch = int(state.get("epoch", 1))
+        print(f"[train] Resumed at epoch={resume_epoch} step={global_step}")
+
+    steps_per_epoch = len(train_loader) // config.grad_accum_steps
 
     for epoch in range(1, config.num_epochs + 1):
+        if epoch < resume_epoch:
+            continue
         model.train()
         running_task_loss = 0.0
         running_align_loss = 0.0
+        running_align_count = 0  # micro-batches with non-zero alignment loss
 
-        for step, batch in enumerate(train_loader, start=1):
+        # On the resume epoch, skip the micro-batches already consumed.
+        loader_for_epoch = train_loader
+        if config.resume_from and epoch == resume_epoch and global_step > 0:
+            steps_in_prior_epochs = (resume_epoch - 1) * steps_per_epoch
+            optim_steps_into_epoch = global_step - steps_in_prior_epochs
+            micro_batches_to_skip = optim_steps_into_epoch * config.grad_accum_steps
+            if micro_batches_to_skip > 0:
+                print(
+                    f"[train] skipping {micro_batches_to_skip} micro-batches "
+                    f"({optim_steps_into_epoch} optimizer steps) in epoch {epoch}"
+                )
+                loader_for_epoch = accelerator.skip_first_batches(
+                    train_loader, micro_batches_to_skip
+                )
+
+        for step, batch in enumerate(loader_for_epoch, start=1):
             with accelerator.accumulate(model):
                 # Separate alignment metadata before passing to model
                 has_alignment = batch.pop("has_alignment")
@@ -760,7 +814,10 @@ def main(config: Config):
                 optimizer.zero_grad()
 
             running_task_loss += task_loss.detach().item()
-            running_align_loss += alignment_loss.detach().item()
+            align_val = alignment_loss.detach().item()
+            running_align_loss += align_val
+            if align_val != 0.0:
+                running_align_count += 1
 
             if accelerator.sync_gradients:
                 global_step += 1
@@ -769,17 +826,47 @@ def main(config: Config):
                     global_step % config.log_every == 0
                     and accelerator.is_main_process
                 ):
-                    avg_task = running_task_loss / config.log_every
-                    avg_align = running_align_loss / config.log_every
+                    # log_every counts optimizer steps; accumulation is over
+                    # log_every * grad_accum_steps micro-batches.
+                    n_micro = config.log_every * config.grad_accum_steps
+                    avg_task = running_task_loss / n_micro
+                    avg_align = (
+                        running_align_loss / running_align_count
+                        if running_align_count > 0
+                        else 0.0
+                    )
+                    align_frac = running_align_count / n_micro
                     lr_now = scheduler.get_last_lr()[0]
                     print(
                         f"[train] epoch={epoch} step={global_step} "
                         f"task_loss={avg_task:.4f} "
                         f"align_loss={avg_align:.4f} "
+                        f"align_frac={align_frac:.3f} "
                         f"lr={lr_now:.2e}"
                     )
                     running_task_loss = 0.0
                     running_align_loss = 0.0
+                    running_align_count = 0
+
+                # --- Mid-epoch checkpoint save ---
+                if config.save_steps > 0 and global_step % config.save_steps == 0:
+                    state_dir = f"{config.output_dir}/checkpoint-{global_step}"
+                    accelerator.save_state(state_dir)
+                    if accelerator.is_main_process:
+                        with open(f"{state_dir}/training_state.json", "w") as fh:
+                            json.dump(
+                                {"epoch": epoch, "global_step": global_step}, fh
+                            )
+                        # Rotation: keep last save_total_limit; preserve best_model/
+                        existing = sorted(
+                            glob_files(f"{config.output_dir}/checkpoint-*"),
+                            key=lambda p: int(p.rsplit("-", 1)[-1]),
+                        )
+                        while len(existing) > config.save_total_limit:
+                            old = existing.pop(0)
+                            shutil.rmtree(old, ignore_errors=True)
+                            print(f"[train] rotated out {old}")
+                        print(f"[train] saved checkpoint to {state_dir}")
 
         # --- Validation at end of each epoch ---
         print(f"[train] Running validation after epoch {epoch}...")
@@ -893,6 +980,36 @@ if __name__ == "__main__":
         type=int,
         default=Config.num_val_samples,
         help="Slice val split to N rows (0 = full). Useful for smoke tests.",
+    )
+    parser.add_argument(
+        "--save_steps",
+        type=int,
+        default=Config.save_steps,
+        help="Save a full training state (model+optimizer+scheduler+RNG) every "
+             "N optimizer steps. 0 disables mid-epoch saves (only end-of-epoch "
+             "best_model is kept).",
+    )
+    parser.add_argument(
+        "--save_total_limit",
+        type=int,
+        default=Config.save_total_limit,
+        help="Keep at most this many checkpoint-* dirs (best_model/ is always "
+             "preserved). Older ones are deleted in order.",
+    )
+    parser.add_argument(
+        "--resume_from",
+        type=str,
+        default=Config.resume_from,
+        help="Path to a checkpoint-* dir to resume training from. Restores "
+             "model, optimizer, scheduler, RNG, epoch, and global_step.",
+    )
+    parser.add_argument(
+        "--aligned_only",
+        action="store_true",
+        default=Config.aligned_only,
+        help="Train only on items whose image has matching precomputed "
+             "alignment data (every batch contributes alignment gradient). "
+             "Val split is always unfiltered for comparability across runs.",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## Summary

- **CoSyn-400K preprocessing pipeline** — OCR detection, bounding box → visual token mapping, per-layer text hidden state extraction (`src/preprocess_cosyn.py`, `src/token_map.py`)
- **Qwen3-VL fine-tuning loop** with frozen vision encoder, auxiliary alignment loss at a configurable LM layer via forward hook, mid-epoch checkpointing, and `--resume_from` support (`src/train_qwen_cosyn.py`)
- **Two alignment loss formulations** — raw L2/MSE and frozen-LM-head bag-of-words probe (`src/losses.py`)
- **Layer sweep diagnostic** identifying layer 26 as the optimal alignment target (`scripts/calibrate_alignment.py`)
- **EM/F1 evaluation script** on 200-item held-out slice (`scripts/eval_table_metrics.py`)
- **Launch and watchdog scripts** for survivable long-running GPU training (`scripts/launch_align.sh`, `scripts/watchdog.sh`)
- **Four-run experimental comparison**: zero-shot, task+MSE, task-only, task+lm_head_bow — alignment is learnable (NLL 10.68 → 6.03) but does not improve downstream EM (0.485 vs 0.495 baseline)

## Files changed

| File | Description |
|------|-------------|
| `src/preprocess_cosyn.py` | CoSyn-400K preprocessing → `.pt` alignment targets |
| `src/token_map.py` | OCR bbox → Qwen3-VL visual token index mapping |
| `src/train_qwen_cosyn.py` | Training loop with alignment hook, checkpointing, resume |
| `src/losses.py` | Added `compute_lm_head_bow_loss` |
| `scripts/calibrate_alignment.py` | Layer sweep + weight calibration + lm_head_bow probe |
| `scripts/eval_table_metrics.py` | EM / token-F1 evaluation |
| `scripts/launch_align.sh` | Unbuffered launch wrapper |
| `scripts/watchdog.sh` | Process + log-staleness watchdog |
| `.gitignore` | Exclude `data/` (precomputed artifacts) |
| `README.md` | Detailed academic writeup of methodology and results |

## Results

| Run | EM (n=200) | Token F1 |
|-----|-----------|----------|
| Zero-shot | 0.000 | 0.051 |
| Task + MSE (w=1e-5, L16) | 0.500 | 0.586 |
| Task-only | 0.495 | 0.584 |
| Task + lm_head_bow (w=0.04, L26) | 0.485 | 0.573 |

## Test plan

- [ ] Verify `python -m pytest tests/ -v -s` passes locally
- [ ] Confirm README renders correctly on GitHub
- [ ] Spot-check that `.gitignore` excludes `data/` properly